### PR TITLE
Identity resolver cache + profile resolution integration

### DIFF
--- a/docs/plans/2026-01-29-did-resolution-cache-proposal.md
+++ b/docs/plans/2026-01-29-did-resolution-cache-proposal.md
@@ -1,0 +1,177 @@
+# DID Resolution & Persisted Identity Cache Proposal
+
+Date: 2026-01-29
+
+## Context
+
+The CLI currently resolves identities in two places:
+
+- **Handle → DID**: `BskyClient.resolveHandle` calls `com.atproto.identity.resolveHandle` directly and returns a DID with no caching.
+- **DID → handle**: `ProfileResolver` calls `app.bsky.actor.getProfiles` in a batched `RequestResolver` with an **in-memory request cache** only (no persistence).
+
+As we add more graph, feed, and engagement features, identity resolution becomes a hot path. We should avoid repeated calls to Bluesky APIs, improve ergonomics, and keep the implementation Effect-idiomatic.
+
+## Goals
+
+- Provide a **read-through, persisted cache** for handle↔DID mappings to reduce API calls across CLI runs.
+- Centralize identity resolution behind a **single Effect service** so commands don’t need to care about resolution semantics.
+- Keep behavior **deterministic, configurable, and testable** (Effect `Context.Tag` + `Layer`).
+- Balance correctness with performance: short-lived negative caches, reasonable TTLs for valid identities.
+
+## Non-goals
+
+- Full DID document validation, PLC audit log validation, or DNS resolution (we continue to rely on PDS APIs).
+- Global identity sync via Jetstream/PLC feeds (possible later phase).
+- Replacing all profile hydration in one pass; scope is identity resolution + caching.
+
+## References (local)
+
+- `.reference/bsky-docs/docs/advanced-guides/resolving-identities.md`
+  - Recommends **identity caches** with a **max TTL of 24 hours** for core identity data and **shorter TTLs (~5 minutes)** for failures.
+- `com.atproto.identity.*` lexicons in `.reference/bsky-docs/atproto-openapi-types/lexicons/`:
+  - `resolveHandle` (handle → DID)
+  - `resolveDid` (DID → DID doc)
+  - `resolveIdentity` (handle or DID → DID + verified handle + DID doc)
+
+## Current Code Findings
+
+- `ProfileResolver` uses `Request.makeCache` for in-run caching only (no persistence).
+- `KeyValueStore` with filesystem backing is already set up (`src/cli/layers.ts` stores under `${storeRoot}/kv`).
+- Existing TTL cache patterns exist in:
+  - `src/services/link-validator.ts`
+  - `src/services/trending-topics.ts`
+
+These are a good blueprint for a persisted identity cache.
+
+## Proposed Design
+
+### 1) New Service: `IdentityResolver`
+
+Create a new service to centralize identity resolution and caching:
+
+```ts
+export class IdentityResolver extends Context.Tag("@skygent/IdentityResolver")<
+  IdentityResolver,
+  {
+    readonly resolveDid: (handle: string) => Effect.Effect<Did, BskyError>
+    readonly resolveHandle: (did: string) => Effect.Effect<Handle, BskyError>
+    readonly resolveIdentity: (
+      identifier: string
+    ) => Effect.Effect<IdentityInfo, BskyError>
+  }
+>() {}
+```
+
+- **`resolveDid(handle)`** → uses cache; falls back to `com.atproto.identity.resolveHandle`.
+- **`resolveHandle(did)`** → uses cache; falls back to `app.bsky.actor.getProfiles` or `com.atproto.identity.resolveIdentity` (see “Semantics” below).
+- **`resolveIdentity(identifier)`** → optional API that returns both sides plus DID doc (future CLI command + debugging).
+
+### 2) Persisted Cache Layout
+
+Use `KeyValueStore` with schema-validated entries and TTL checks:
+
+- Prefix: `cache/identity/handle/` keyed by normalized handle (lowercase).
+- Prefix: `cache/identity/did/` keyed by DID string.
+- **Key encoding:** use `encodeURIComponent` for both handle and DID keys to avoid filesystem/path edge cases (mirrors `LinkValidator`).
+
+Suggested cache entry model:
+
+```ts
+class IdentityCacheEntry extends Schema.Class<IdentityCacheEntry>("IdentityCacheEntry")({
+  did: Schema.optional(Did),
+  handle: Schema.optional(Handle),
+  verified: Schema.Boolean,
+  status: Schema.Literal("resolved", "not_found", "deactivated", "invalid"),
+  source: Schema.Literal("resolveHandle", "getProfiles", "resolveIdentity"),
+  checkedAt: Schema.DateFromString
+}) {}
+```
+
+- Store **both directions** on successful resolution.
+- Store **negative entries** (e.g., handle not found) with shorter TTL.
+- If `resolveIdentity` returns `handle.invalid`, record `status = "invalid"` and do **not** treat the handle as resolved.
+
+### 3) TTL Policy (Configurable)
+
+Defaults aligned with Bluesky docs:
+
+- `SKYGENT_IDENTITY_CACHE_TTL` → **24 hours** (positive entries).
+- `SKYGENT_IDENTITY_FAILURE_TTL` → **5 minutes** (negative entries).
+- Optional: `SKYGENT_IDENTITY_REQUEST_CACHE_CAPACITY` (in-memory request cache for deduping within a run, default 5000).
+- **Disabling:** allow TTL or capacity ≤ 0 to disable persisted or in-memory caching (mirrors `ProfileResolver` patterns).
+
+All should use `Effect.Config` and provide overrides via env/config file.
+
+### 4) Resolution Semantics
+
+- **Handle → DID** should always use `resolveHandle`, since it’s the canonical API.
+- **DID → handle** has two options:
+  1) **Fast path:** `app.bsky.actor.getProfiles` (current behavior). This returns the handle in the profile record (not necessarily verified against the DID doc).
+  2) **Strict path (optional):** `com.atproto.identity.resolveIdentity` for verified handle + DID doc.
+
+Recommendation:
+
+- Default to **fast path** for CLI display (ergonomics + speed).
+- Add `SKYGENT_IDENTITY_STRICT=true` (or a CLI `--strict-identity` option) to use `resolveIdentity` when correctness matters.
+- In strict mode, prefer `resolveIdentity` for **both** handle→DID and DID→handle lookups.
+- **Strict cache rule:** when strict mode is on, ignore cache entries with `verified = false` (e.g., those sourced from `getProfiles`).
+
+### 5) Integration Points
+
+- Replace direct calls to `BskyClient.resolveHandle` in CLI commands with `IdentityResolver.resolveDid`.
+- Replace `ProfileResolver` usage with `IdentityResolver.resolveHandle` where persisted caching is desired.
+- Keep `ProfileResolver` for high-throughput DID→handle batch resolution in jetstream sync if needed, but consider delegating to `IdentityResolver` for cache hits.
+- Add `IdentityResolver.layer` to `src/cli/layers.ts`, wired with `KeyValueStore` (persisted cache) and `BskyClient`.
+
+### 6) Error Handling & Negative Caching
+
+- Cache “not found” or “deactivated” responses with a **short TTL** to avoid rapid retry loops.
+- Treat unexpected errors as non-cacheable (unless explicitly configured).
+- Map KV read/write/decode failures into `BskyError` with a clear `operation` label (consistent with existing services).
+- Cache decode failures can be treated as a cache miss (and optionally re-written with a fresh entry).
+
+### 7) Testing
+
+- Provide `IdentityResolver.testLayer` with a `Map`-backed store.
+- Add unit tests for TTL logic, negative caching, and read-through behavior.
+- Cover `resolveDid` and `resolveHandle` integration with mocked `BskyClient`.
+
+## Performance & Ergonomics Notes
+
+- **Request-level caching** (via `Request.makeCache`) prevents duplicate lookups during a single run; for non-batched lookups, a small `Cache` or request cache can still coalesce concurrent requests.
+- **Persisted KV cache** prevents repeated network calls across runs.
+- Resolution can be safely parallelized; persist writes should be batched when possible.
+- Ensure handle normalization (lowercase) to maximize cache hits.
+
+## Phased Implementation Plan
+
+### Phase 1 — Service & Cache Foundation
+
+- Add `IdentityResolver` service with read-through cache using `KeyValueStore`.
+- Implement schema-based cache entries and TTL checks.
+- Use `Config` for TTL + capacity options.
+- Add test layer + initial tests.
+
+### Phase 2 — CLI Integration
+
+- Update graph commands, search filters, and other identity-sensitive code paths to use `IdentityResolver`.
+- Decide whether to deprecate or keep `ProfileResolver` (likely keep for batch lookups; it can be updated to consult the persisted cache first).
+- Add optional strict-resolution mode (config or CLI flag).
+
+### Phase 3 — Identity Tools & Proactive Refresh
+
+- Add `skygent identity resolve <handle|did>` command for debugging.
+- Add a cache management command (e.g., `skygent cache identity clear|refresh`).
+- Explore Jetstream identity events for proactive cache updates (optional).
+
+## Open Questions
+
+1. **Strictness:** should DID→handle default to `resolveIdentity` for verified handles, or keep `getProfiles` for speed? (Proposal: keep `getProfiles` default, allow strict mode.)
+2. **Cache scope:** the KV store is global under `${storeRoot}/kv`. This is good for sharing across stores; confirm this is desired.
+3. **Negative caching defaults:** recommended TTLs are short (5–15 minutes). Confirm the desired default.
+
+## Next Steps
+
+- Confirm semantics for DID→handle resolution (fast vs strict default).
+- Agree on TTL defaults and config names.
+- Implement Phase 1 in code and wire into CLI layers.

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,6 +1,7 @@
 import { Args, Command, Options } from "@effect/cli";
 import { Effect, Option, Stream } from "effect";
 import { BskyClient } from "../services/bsky-client.js";
+import { IdentityResolver } from "../services/identity-resolver.js";
 import type { ListItemView, ListView, ProfileView, RelationshipView } from "../domain/bsky.js";
 import { decodeActor } from "./shared-options.js";
 import { CliInputError } from "./errors.js";
@@ -250,13 +251,14 @@ const relationshipsCommand = Command.make(
   ({ actor, others, format }) =>
     Effect.gen(function* () {
       const client = yield* BskyClient;
+      const identities = yield* IdentityResolver;
       const resolveDid = (value: string) =>
         Effect.gen(function* () {
           const decoded = yield* decodeActor(value);
           const actorValue = String(decoded);
           return actorValue.startsWith("did:")
             ? actorValue
-            : yield* client.resolveHandle(actorValue);
+            : yield* identities.resolveDid(actorValue);
         });
       const resolvedActor = yield* resolveDid(actor);
       const parsedOthers = others

--- a/src/cli/layers.ts
+++ b/src/cli/layers.ts
@@ -32,6 +32,7 @@ import { OutputManager } from "../services/output-manager.js";
 import { FilterLibrary } from "../services/filter-library.js";
 import { StoreStats } from "../services/store-stats.js";
 import { ProfileResolver } from "../services/profile-resolver.js";
+import { IdentityResolver } from "../services/identity-resolver.js";
 import { StoreLock } from "../services/store-lock.js";
 
 const appConfigLayer = AppConfigService.layer;
@@ -96,8 +97,13 @@ const syncLayer = SyncEngine.layer.pipe(
   Layer.provideMerge(SyncReporter.layer),
   Layer.provideMerge(syncSettingsLayer)
 );
-const profileResolverLayer = ProfileResolver.layer.pipe(
+const identityResolverLayer = IdentityResolver.layer.pipe(
+  Layer.provideMerge(storageLayer),
   Layer.provideMerge(bskyLayer)
+);
+const profileResolverLayer = ProfileResolver.layer.pipe(
+  Layer.provideMerge(bskyLayer),
+  Layer.provideMerge(identityResolverLayer)
 );
 const storeLockLayer = StoreLock.layer.pipe(
   Layer.provideMerge(appConfigLayer)
@@ -168,5 +174,6 @@ export const CliLive = Layer.mergeAll(
   postParserLayer,
   filterLibraryLayer,
   profileResolverLayer,
+  identityResolverLayer,
   storeLockLayer
 );

--- a/src/domain/bsky.ts
+++ b/src/domain/bsky.ts
@@ -178,6 +178,12 @@ export class ProfileView extends Schema.Class<ProfileView>("ProfileView")({
   debug: Schema.optional(Schema.Unknown)
 }) {}
 
+export class IdentityInfo extends Schema.Class<IdentityInfo>("IdentityInfo")({
+  did: Did,
+  handle: Handle,
+  didDoc: Schema.Unknown
+}) {}
+
 export class EmbedRecordView extends Schema.TaggedClass<EmbedRecordView>()(
   "RecordView",
   {

--- a/src/services/identity-resolver.ts
+++ b/src/services/identity-resolver.ts
@@ -1,0 +1,496 @@
+import * as KeyValueStore from "@effect/platform/KeyValueStore";
+import {
+  Cache,
+  Clock,
+  Config,
+  Context,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  ParseResult,
+  Schema
+} from "effect";
+import { IdentityInfo } from "../domain/bsky.js";
+import { BskyError } from "../domain/errors.js";
+import { Did, Handle } from "../domain/primitives.js";
+import { formatSchemaError, messageFromCause } from "./shared.js";
+import { BskyClient } from "./bsky-client.js";
+
+const cachePrefixHandle = "cache/identity/handle/";
+const cachePrefixDid = "cache/identity/did/";
+
+const normalizeHandleInput = (value: string) => {
+  const trimmed = value.trim();
+  const normalized = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
+  return normalized.toLowerCase();
+};
+
+const isHandleInvalid = (handle: Handle) => handle === "handle.invalid";
+
+const toIdentityError = (message: string, operation?: string) => (cause: unknown) =>
+  BskyError.make({
+    message: messageFromCause(message, cause),
+    cause,
+    ...(operation ? { operation } : {})
+  });
+
+const decodeHandle = (value: string) =>
+  Schema.decodeUnknown(Handle)(normalizeHandleInput(value)).pipe(
+    Effect.mapError((error) =>
+      BskyError.make({
+        message: `Invalid handle: ${formatSchemaError(error)}`,
+        cause: { handle: value },
+        operation: "identityDecodeHandle"
+      })
+    )
+  );
+
+const decodeDid = (value: string) =>
+  Schema.decodeUnknown(Did)(value).pipe(
+    Effect.mapError((error) =>
+      BskyError.make({
+        message: `Invalid DID: ${formatSchemaError(error)}`,
+        cause: { did: value },
+        operation: "identityDecodeDid"
+      })
+    )
+  );
+
+class IdentityCacheEntry extends Schema.Class<IdentityCacheEntry>("IdentityCacheEntry")({
+  did: Schema.optional(Did),
+  handle: Schema.optional(Handle),
+  verified: Schema.Boolean,
+  status: Schema.Literal("resolved", "not_found", "deactivated", "invalid"),
+  source: Schema.Literal("resolveHandle", "getProfiles", "resolveIdentity"),
+  checkedAt: Schema.DateFromString
+}) {}
+
+type IdentityStatus = IdentityCacheEntry["status"];
+
+type CacheStores = {
+  readonly handleStore: KeyValueStore.SchemaStore<IdentityCacheEntry, never>;
+  readonly didStore: KeyValueStore.SchemaStore<IdentityCacheEntry, never>;
+};
+
+const cacheKey = (value: string) => encodeURIComponent(value);
+
+const makeCacheStores = (kv: KeyValueStore.KeyValueStore): CacheStores => {
+  const store = kv.forSchema(IdentityCacheEntry);
+  return {
+    handleStore: KeyValueStore.prefix(store, cachePrefixHandle),
+    didStore: KeyValueStore.prefix(store, cachePrefixDid)
+  };
+};
+
+const entryStatusError = (
+  status: IdentityStatus,
+  identifier: string,
+  kind: "handle" | "did"
+) => {
+  if (status === "not_found") {
+    return BskyError.make({
+      message:
+        kind === "handle"
+          ? `Handle not found: ${identifier}`
+          : `DID not found: ${identifier}`,
+      error: kind === "handle" ? "HandleNotFound" : "DidNotFound",
+      operation: kind === "handle" ? "resolveDid" : "resolveHandle"
+    });
+  }
+  if (status === "deactivated") {
+    return BskyError.make({
+      message: `DID deactivated: ${identifier}`,
+      error: "DidDeactivated",
+      operation: "resolveHandle"
+    });
+  }
+  return BskyError.make({
+    message: `Handle invalid for ${identifier}`,
+    error: "HandleInvalid",
+    operation: kind === "handle" ? "resolveDid" : "resolveHandle"
+  });
+};
+
+export class IdentityResolver extends Context.Tag("@skygent/IdentityResolver")<
+  IdentityResolver,
+  {
+    readonly lookupDid: (handle: string) => Effect.Effect<Option.Option<Did>, BskyError>;
+    readonly lookupHandle: (did: string) => Effect.Effect<Option.Option<Handle>, BskyError>;
+    readonly resolveDid: (handle: string) => Effect.Effect<Did, BskyError>;
+    readonly resolveHandle: (did: string) => Effect.Effect<Handle, BskyError>;
+    readonly resolveIdentity: (
+      identifier: string
+    ) => Effect.Effect<IdentityInfo, BskyError>;
+    readonly cacheProfile: (input: {
+      readonly did: Did;
+      readonly handle: Handle;
+      readonly verified?: boolean;
+      readonly source?: IdentityCacheEntry["source"];
+    }) => Effect.Effect<void, BskyError>;
+  }
+>() {
+  static readonly layer = Layer.effect(
+    IdentityResolver,
+    Effect.gen(function* () {
+      const bsky = yield* BskyClient;
+      const kv = yield* KeyValueStore.KeyValueStore;
+      const { handleStore, didStore } = makeCacheStores(kv);
+
+      const cacheTtl = yield* Config.duration("SKYGENT_IDENTITY_CACHE_TTL").pipe(
+        Config.withDefault(Duration.hours(24))
+      );
+      const failureTtl = yield* Config.duration("SKYGENT_IDENTITY_FAILURE_TTL").pipe(
+        Config.withDefault(Duration.minutes(5))
+      );
+      const strict = yield* Config.boolean("SKYGENT_IDENTITY_STRICT").pipe(
+        Config.withDefault(false)
+      );
+      const requestCapacity = yield* Config.integer(
+        "SKYGENT_IDENTITY_REQUEST_CACHE_CAPACITY"
+      ).pipe(Config.withDefault(5000));
+
+      const successTtlMs = Duration.toMillis(cacheTtl);
+      const failureTtlMs = Duration.toMillis(failureTtl);
+
+      const entryTtl = (entry: IdentityCacheEntry) =>
+        entry.status === "resolved" ? cacheTtl : failureTtl;
+
+      const isFresh = (entry: IdentityCacheEntry, now: number) => {
+        const ttlMs = Duration.toMillis(entryTtl(entry));
+        return ttlMs > 0 && now - entry.checkedAt.getTime() < ttlMs;
+      };
+
+      const shouldPersist = (entry: IdentityCacheEntry) =>
+        Duration.toMillis(entryTtl(entry)) > 0;
+
+      const readEntry = (
+        store: KeyValueStore.SchemaStore<IdentityCacheEntry, never>,
+        key: string,
+        now: number
+      ) =>
+        store.get(key).pipe(
+          Effect.catchAll((error) =>
+            ParseResult.isParseError(error)
+              ? Effect.succeed(Option.none())
+              : Effect.fail(
+                  toIdentityError("Identity cache read failed", "identityCacheRead")(
+                    error
+                  )
+                )
+          ),
+          Effect.map((cached) =>
+            Option.filter(cached, (entry) =>
+              isFresh(entry, now) && (!strict || entry.verified)
+            )
+          )
+        );
+
+      const writeEntry = (
+        store: KeyValueStore.SchemaStore<IdentityCacheEntry, never>,
+        key: string,
+        entry: IdentityCacheEntry
+      ) =>
+        store
+          .set(key, entry)
+          .pipe(
+            Effect.mapError(
+              toIdentityError("Identity cache write failed", "identityCacheWrite")
+            )
+          );
+
+      const writeResolvedEntry = (entry: IdentityCacheEntry) => {
+        if (!shouldPersist(entry)) {
+          return Effect.void;
+        }
+        const effects: Array<Effect.Effect<void, BskyError>> = [];
+        if (entry.handle) {
+          effects.push(
+            writeEntry(handleStore, cacheKey(entry.handle), entry)
+          );
+        }
+        if (entry.did) {
+          effects.push(writeEntry(didStore, cacheKey(entry.did), entry));
+        }
+        if (effects.length === 0) {
+          return Effect.void;
+        }
+        return Effect.all(effects, { discard: true });
+      };
+
+      const cacheProfile = Effect.fn("IdentityResolver.cacheProfile")(
+        (input: {
+          readonly did: Did;
+          readonly handle: Handle;
+          readonly verified?: boolean;
+          readonly source?: IdentityCacheEntry["source"];
+        }) =>
+          Effect.gen(function* () {
+            const now = yield* Clock.currentTimeMillis;
+            const entry = IdentityCacheEntry.make({
+              did: input.did,
+              handle: input.handle,
+              verified: input.verified ?? false,
+              status: "resolved",
+              source: input.source ?? "getProfiles",
+              checkedAt: new Date(now)
+            });
+            yield* writeResolvedEntry(entry);
+          })
+      );
+
+      const writeNegativeEntry = (
+        entry: IdentityCacheEntry,
+        target: "handle" | "did",
+        key: string
+      ) => {
+        if (!shouldPersist(entry)) {
+          return Effect.void;
+        }
+        const store = target === "handle" ? handleStore : didStore;
+        return writeEntry(store, cacheKey(key), entry).pipe(Effect.asVoid);
+      };
+
+      const resolveDidFromCache = (handle: Handle) =>
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          const cached = yield* readEntry(handleStore, cacheKey(handle), now);
+          if (Option.isNone(cached)) {
+            return Option.none<Did>();
+          }
+          const entry = cached.value;
+          if (entry.status === "resolved") {
+            return entry.did ? Option.some(entry.did) : Option.none<Did>();
+          }
+          const identifier =
+            entry.status === "deactivated" && entry.did ? entry.did : handle;
+          const kind = entry.status === "deactivated" ? "did" : "handle";
+          return yield* entryStatusError(entry.status, identifier, kind);
+        });
+
+      const resolveHandleFromCache = (did: Did) =>
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis;
+          const cached = yield* readEntry(didStore, cacheKey(did), now);
+          if (Option.isNone(cached)) {
+            return Option.none<Handle>();
+          }
+          const entry = cached.value;
+          if (entry.status === "resolved") {
+            return entry.handle ? Option.some(entry.handle) : Option.none<Handle>();
+          }
+          return yield* entryStatusError(entry.status, did, "did");
+        });
+
+      const resolveViaResolveIdentity = (identifier: string) =>
+        Effect.gen(function* () {
+          const info = yield* bsky.resolveIdentity(identifier);
+          const now = yield* Clock.currentTimeMillis;
+          const invalid = isHandleInvalid(info.handle);
+          const entry = IdentityCacheEntry.make({
+            did: info.did,
+            ...(invalid ? {} : { handle: info.handle }),
+            verified: !invalid,
+            status: invalid ? "invalid" : "resolved",
+            source: "resolveIdentity",
+            checkedAt: new Date(now)
+          });
+
+          if (invalid) {
+            const key = identifier.startsWith("did:") ? info.did : identifier;
+            const target = identifier.startsWith("did:") ? "did" : "handle";
+            yield* writeNegativeEntry(entry, target, key);
+            return yield* entryStatusError("invalid", identifier, target);
+          }
+
+          yield* writeResolvedEntry(entry);
+          return info;
+        }).pipe(
+          Effect.catchTag("BskyError", (error) =>
+            Effect.gen(function* () {
+              if (
+                error.error === "HandleNotFound" ||
+                error.error === "DidNotFound" ||
+                error.error === "DidDeactivated"
+              ) {
+                const now = yield* Clock.currentTimeMillis;
+                const isDid = identifier.startsWith("did:");
+                const status =
+                  error.error === "DidDeactivated" ? "deactivated" : "not_found";
+                const entry = IdentityCacheEntry.make({
+                  ...(isDid ? { did: identifier as Did } : { handle: identifier as Handle }),
+                  verified: false,
+                  status,
+                  source: "resolveIdentity",
+                  checkedAt: new Date(now)
+                });
+                yield* writeNegativeEntry(entry, isDid ? "did" : "handle", identifier);
+              }
+              return yield* error;
+            })
+          )
+        );
+
+      const resolveDidUncached = (handle: Handle) =>
+        Effect.gen(function* () {
+          const cached = yield* resolveDidFromCache(handle);
+          if (Option.isSome(cached)) {
+            return cached.value;
+          }
+
+          if (strict) {
+            const info = yield* resolveViaResolveIdentity(handle);
+            return info.did;
+          }
+
+          const did = yield* bsky.resolveHandle(handle).pipe(
+            Effect.catchTag("BskyError", (error) =>
+              Effect.gen(function* () {
+                if (error.error === "HandleNotFound") {
+                  const now = yield* Clock.currentTimeMillis;
+                  const entry = IdentityCacheEntry.make({
+                    handle,
+                    verified: false,
+                    status: "not_found",
+                    source: "resolveHandle",
+                    checkedAt: new Date(now)
+                  });
+                  yield* writeNegativeEntry(entry, "handle", handle);
+                }
+                return yield* error;
+              })
+            )
+          );
+
+          const now = yield* Clock.currentTimeMillis;
+          const entry = IdentityCacheEntry.make({
+            did,
+            handle,
+            verified: false,
+            status: "resolved",
+            source: "resolveHandle",
+            checkedAt: new Date(now)
+          });
+          yield* writeResolvedEntry(entry);
+          return did;
+        });
+
+      const resolveHandleUncached = (did: Did) =>
+        Effect.gen(function* () {
+          const cached = yield* resolveHandleFromCache(did);
+          if (Option.isSome(cached)) {
+            return cached.value;
+          }
+
+          if (strict) {
+            const info = yield* resolveViaResolveIdentity(did);
+            return info.handle;
+          }
+
+          const profiles = yield* bsky.getProfiles([did]);
+          const profile = profiles[0];
+          if (!profile) {
+            const error = BskyError.make({
+              message: `Profile not found for DID ${did}`,
+              error: "ProfileNotFound",
+              operation: "getProfiles"
+            });
+            const now = yield* Clock.currentTimeMillis;
+            const entry = IdentityCacheEntry.make({
+              did,
+              verified: false,
+              status: "not_found",
+              source: "getProfiles",
+              checkedAt: new Date(now)
+            });
+            yield* writeNegativeEntry(entry, "did", did);
+            return yield* error;
+          }
+
+          const now = yield* Clock.currentTimeMillis;
+          const entry = IdentityCacheEntry.make({
+            did,
+            handle: profile.handle,
+            verified: false,
+            status: "resolved",
+            source: "getProfiles",
+            checkedAt: new Date(now)
+          });
+          yield* writeResolvedEntry(entry);
+          return profile.handle;
+        });
+
+      const makeRequestCache = <K, V>(
+        lookup: (key: K) => Effect.Effect<V, BskyError>
+      ) => {
+        if (requestCapacity <= 0 || (successTtlMs <= 0 && failureTtlMs <= 0)) {
+          return Effect.succeed(Option.none<Cache.Cache<K, V, BskyError>>());
+        }
+        return Cache.makeWith({
+          capacity: requestCapacity,
+          lookup,
+          timeToLive: (exit) =>
+            exit._tag === "Failure" ? failureTtl : cacheTtl
+        }).pipe(Effect.map(Option.some));
+      };
+
+      const resolveDidCache = yield* makeRequestCache(resolveDidUncached);
+      const resolveHandleCache = yield* makeRequestCache(resolveHandleUncached);
+
+      const resolveDid = Effect.fn("IdentityResolver.resolveDid")((handle: string) =>
+        Effect.gen(function* () {
+          const normalized = yield* decodeHandle(handle);
+          const effect = Option.match(resolveDidCache, {
+            onNone: () => resolveDidUncached(normalized),
+            onSome: (cache) => cache.get(normalized)
+          });
+          return yield* effect;
+        })
+      );
+
+      const lookupDid = Effect.fn("IdentityResolver.lookupDid")((handle: string) =>
+        Effect.gen(function* () {
+          const normalized = yield* decodeHandle(handle);
+          return yield* resolveDidFromCache(normalized);
+        })
+      );
+
+      const resolveHandle = Effect.fn("IdentityResolver.resolveHandle")((did: string) =>
+        Effect.gen(function* () {
+          const normalized = yield* decodeDid(did);
+          const effect = Option.match(resolveHandleCache, {
+            onNone: () => resolveHandleUncached(normalized),
+            onSome: (cache) => cache.get(normalized)
+          });
+          return yield* effect;
+        })
+      );
+
+      const lookupHandle = Effect.fn("IdentityResolver.lookupHandle")((did: string) =>
+        Effect.gen(function* () {
+          const normalized = yield* decodeDid(did);
+          return yield* resolveHandleFromCache(normalized);
+        })
+      );
+
+      const resolveIdentity = Effect.fn("IdentityResolver.resolveIdentity")(
+        (identifier: string) =>
+          Effect.gen(function* () {
+            const normalized = identifier.startsWith("did:")
+              ? yield* decodeDid(identifier)
+              : yield* decodeHandle(identifier);
+            return yield* resolveViaResolveIdentity(normalized);
+          })
+      );
+
+      return IdentityResolver.of({
+        lookupDid,
+        lookupHandle,
+        resolveDid,
+        resolveHandle,
+        resolveIdentity,
+        cacheProfile
+      });
+    })
+  );
+}

--- a/tests/services/identity-resolver.test.ts
+++ b/tests/services/identity-resolver.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { ConfigProvider, Effect, Either, Layer } from "effect";
+import * as KeyValueStore from "@effect/platform/KeyValueStore";
+import { BskyClient } from "../../src/services/bsky-client.js";
+import { IdentityResolver } from "../../src/services/identity-resolver.js";
+import { BskyError } from "../../src/domain/errors.js";
+import { IdentityInfo } from "../../src/domain/bsky.js";
+import { makeBskyClient } from "../support/bsky-client.js";
+
+const envProvider = (entries: Array<readonly [string, string]>) =>
+  Layer.setConfigProvider(ConfigProvider.fromMap(new Map(entries)));
+
+const makeIdentity = (did: string, handle: string) =>
+  IdentityInfo.make({ did, handle, didDoc: {} });
+
+describe("IdentityResolver", () => {
+  test("persists handle lookups", async () => {
+    let calls = 0;
+    const bskyLayer = Layer.succeed(
+      BskyClient,
+      makeBskyClient({
+        resolveHandle: (handle) => {
+          calls += 1;
+          return Effect.succeed(`did:plc:${handle}`);
+        },
+        resolveIdentity: () =>
+          Effect.fail(BskyError.make({ message: "unused" })),
+        getProfiles: () => Effect.succeed([])
+      })
+    );
+
+    const layer = IdentityResolver.layer.pipe(
+      Layer.provide(bskyLayer),
+      Layer.provide(KeyValueStore.layerMemory),
+      Layer.provide(envProvider([["SKYGENT_IDENTITY_REQUEST_CACHE_CAPACITY", "0"]]))
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const resolver = yield* IdentityResolver;
+        const first = yield* resolver.resolveDid("alice.bsky");
+        const second = yield* resolver.resolveDid("alice.bsky");
+        return { first, second };
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(calls).toBe(1);
+    expect(result.first).toBe(result.second);
+  });
+
+  test("caches handle not found failures", async () => {
+    let calls = 0;
+    const notFound = BskyError.make({
+      message: "Handle not found",
+      error: "HandleNotFound"
+    });
+    const bskyLayer = Layer.succeed(
+      BskyClient,
+      makeBskyClient({
+        resolveHandle: () => {
+          calls += 1;
+          return Effect.fail(notFound);
+        },
+        resolveIdentity: () =>
+          Effect.fail(BskyError.make({ message: "unused" })),
+        getProfiles: () => Effect.succeed([])
+      })
+    );
+
+    const layer = IdentityResolver.layer.pipe(
+      Layer.provide(bskyLayer),
+      Layer.provide(KeyValueStore.layerMemory),
+      Layer.provide(envProvider([["SKYGENT_IDENTITY_REQUEST_CACHE_CAPACITY", "0"]]))
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const resolver = yield* IdentityResolver;
+        const first = yield* resolver.resolveDid("missing.bsky").pipe(Effect.either);
+        const second = yield* resolver
+          .resolveDid("missing.bsky")
+          .pipe(Effect.either);
+        return { first, second };
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(calls).toBe(1);
+    expect(Either.isLeft(result.first)).toBe(true);
+    expect(Either.isLeft(result.second)).toBe(true);
+  });
+
+  test("strict mode uses resolveIdentity", async () => {
+    let resolveHandleCalls = 0;
+    let resolveIdentityCalls = 0;
+    const bskyLayer = Layer.succeed(
+      BskyClient,
+      makeBskyClient({
+        resolveHandle: () => {
+          resolveHandleCalls += 1;
+          return Effect.succeed("did:plc:unused");
+        },
+        resolveIdentity: () => {
+          resolveIdentityCalls += 1;
+          return Effect.succeed(makeIdentity("did:plc:strict", "alice.bsky"));
+        },
+        getProfiles: () => Effect.succeed([])
+      })
+    );
+
+    const layer = IdentityResolver.layer.pipe(
+      Layer.provide(bskyLayer),
+      Layer.provide(KeyValueStore.layerMemory),
+      Layer.provide(
+        envProvider([
+          ["SKYGENT_IDENTITY_STRICT", "true"],
+          ["SKYGENT_IDENTITY_REQUEST_CACHE_CAPACITY", "0"]
+        ])
+      )
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const resolver = yield* IdentityResolver;
+        return yield* resolver.resolveDid("alice.bsky");
+      }).pipe(Effect.provide(layer))
+    );
+
+    expect(result).toBe("did:plc:strict");
+    expect(resolveIdentityCalls).toBe(1);
+    expect(resolveHandleCalls).toBe(0);
+  });
+});

--- a/tests/services/sync-engine.test.ts
+++ b/tests/services/sync-engine.test.ts
@@ -22,6 +22,7 @@ import { all, none } from "../../src/domain/filter.js";
 import { RawPost } from "../../src/domain/raw.js";
 import { StoreRef } from "../../src/domain/store.js";
 import { DataSource, SyncCheckpoint } from "../../src/domain/sync.js";
+import { makeBskyClient } from "../support/bsky-client.js";
 
 const sampleRaw = Schema.decodeUnknownSync(RawPost)({
   uri: "at://did:plc:example/app.bsky.feed.post/1",
@@ -39,7 +40,7 @@ const sampleStore = Schema.decodeUnknownSync(StoreRef)({
 
 const bskyLayer = Layer.succeed(
   BskyClient,
-  BskyClient.of({
+  makeBskyClient({
     getTimeline: () => Stream.fromIterable([sampleRaw]),
     getNotifications: () => Stream.empty,
     getFeed: () => Stream.empty,
@@ -215,7 +216,7 @@ describe("SyncEngine", () => {
 
     const cursorBskyLayer = Layer.succeed(
       BskyClient,
-      BskyClient.of({
+      makeBskyClient({
         getTimeline: () => Stream.fromIterable([page1Post, page2Post]),
         getNotifications: () => Stream.empty,
         getFeed: () => Stream.empty,
@@ -294,7 +295,7 @@ describe("SyncEngine", () => {
 
     const cursorBskyLayer = Layer.succeed(
       BskyClient,
-      BskyClient.of({
+      makeBskyClient({
         getTimeline: () => Stream.fromIterable([page1Post]),
         getNotifications: () => Stream.empty,
         getFeed: () => Stream.empty,

--- a/tests/support/bsky-client.ts
+++ b/tests/support/bsky-client.ts
@@ -1,0 +1,44 @@
+import { Effect, Stream } from "effect";
+import { BskyClient } from "../../src/services/bsky-client.js";
+import { BskyError } from "../../src/domain/errors.js";
+
+type BskyClientService = Parameters<typeof BskyClient.of>[0];
+
+type Override = Partial<BskyClientService>;
+
+const unused = () => Effect.fail(BskyError.make({ message: "unused" }));
+const emptyStream = () => Stream.empty;
+
+const defaults: BskyClientService = {
+  getTimeline: emptyStream,
+  getNotifications: emptyStream,
+  getFeed: emptyStream,
+  getListFeed: emptyStream,
+  getAuthorFeed: emptyStream,
+  getPost: unused,
+  getPostThread: unused,
+  getFollowers: unused,
+  getFollows: unused,
+  getKnownFollowers: unused,
+  getRelationships: unused,
+  getList: unused,
+  getLists: unused,
+  getBlocks: unused,
+  getMutes: unused,
+  getFeedGenerator: unused,
+  getFeedGenerators: unused,
+  getActorFeeds: unused,
+  getLikes: unused,
+  getRepostedBy: unused,
+  getQuotes: unused,
+  resolveHandle: unused,
+  resolveIdentity: unused,
+  getProfiles: unused,
+  searchActors: unused,
+  searchFeedGenerators: unused,
+  searchPosts: unused,
+  getTrendingTopics: unused
+};
+
+export const makeBskyClient = (overrides: Override) =>
+  BskyClient.of({ ...defaults, ...overrides });


### PR DESCRIPTION
## Summary

- Add `IdentityResolver` with persisted KV cache, strict mode, and negative caching for handle/DID resolution
- Integrate identity caching into `ProfileResolver` to reduce API calls and reuse persisted results
- Update graph relationships to use cached handle→DID resolution and add shared `BskyClient` test helper

## Test plan

- [x] `bun run --silent typecheck` passes
- [x] Tests added/updated (`identity-resolver.test.ts`, `profile-resolver.test.ts`, `sync-engine.test.ts`)
- [x] Docs/plan updated
- [x] No breaking CLI changes intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)