### PR TITLE
fix: increase handle length limit to support bridged handles (#59)

### DIFF
--- a/src/domain/primitives.ts
+++ b/src/domain/primitives.ts
@@ -1,7 +1,7 @@
 import { Schema } from "effect";
 
 export const Handle = Schema.Lowercase.pipe(
-  Schema.pattern(/^[a-z0-9][a-z0-9.-]{1,63}$/),
+  Schema.pattern(/^[a-z0-9][a-z0-9.-]{1,251}$/),
   Schema.brand("Handle")
 );
 export type Handle = typeof Handle.Type;


### PR DESCRIPTION
## Summary

Fixes #59 - Handle schema was rejecting valid long bridged handles from other protocols.

## Problem

The `Handle` schema limited handles to 64 characters using the regex `^[a-z0-9][a-z0-9.-]{1,63}$`. Bridged users from Nostr (via momostr) and other protocols have handles that exceed this length, causing parse failures.

Example rejected handle:
```
npub1qspus6smkn8mcdxg5jflh50s69vdgtwsd5p74gmjpzp2qekn5duqfv5afj.momostr.pink.ap.brid.gy (87 characters)
```

Error:
```
Expected a string matching the pattern ^[a-z0-9][a-z0-9.-]{1,63}$, actual "npub1qspus6smkn8mcdxg5jflh50s69vdgtwsd5p74gmjpzp2qekn5duqfv5afj.momostr.pink.ap.brid.gy"
```

## Solution

Increased the handle length limit from 64 to 253 characters by updating the regex pattern from `{1,63}` to `{1,251}`. This aligns with the standard DNS domain name length limit (253 characters).

## Changes

- `src/domain/primitives.ts` - Updated Handle schema regex pattern

## Testing

- All 211 existing tests pass
- Type check passes (`bun run typecheck`)
- Schema now accepts handles up to 253 characters

## References

- RFC 1035: Domain names should not exceed 253 characters total
- AT Protocol handles are DNS-based and follow DNS label conventions