### PR TITLE
Fix thread view hangs, filter DSL UX, and hasembed pushdown

### DIFF
--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -42,6 +42,8 @@ Each entry shows a DSL example and the equivalent JSON.
   - `{"_tag":"HasLinks"}`
 - Media: `hasmedia`
   - `{"_tag":"HasMedia"}`
+- Embed: `hasembed`
+  - `{"_tag":"HasEmbed"}`
 - Language: `language:en,es`
   - `{"_tag":"Language","langs":["en","es"]}`
 
@@ -81,8 +83,18 @@ Defaults:
 - NOT: `NOT expr`
   - `{"_tag":"Not","expr":{...}}`
 
+## Aliases
+
+- `from:alice` → `author:alice`
+- `tag:#ai` → `hashtag:#ai`
+- `text:"hello"` → `contains:"hello"`
+- `lang:en` → `language:en`
+- `authors:alice,bob` → `authorin:alice,bob`
+- `tags:#ai,#ml` → `hashtagin:#ai,#ml`
+- `is:reply|quote|repost|original`
+- `has:images|video|links|media|embed`
+
 ## Named filters
 
 - Save: `skygent filter create tech --filter 'hashtag:#tech'`
 - Use: `@tech AND author:user.bsky.social`
-

--- a/index.ts
+++ b/index.ts
@@ -94,11 +94,8 @@ const errorDetails = (
     return {
       error: {
         _tag: "BskyError",
-        message: error.message,
         ...(error.operation ? { operation: error.operation } : {}),
-        ...(typeof error.status === "number" ? { status: error.status } : {}),
-        ...(error.error ? { error: error.error } : {}),
-        ...(error.detail ? { detail: error.detail } : {})
+        ...(typeof error.status === "number" ? { status: error.status } : {})
       }
     };
   }

--- a/src/cli/doc/filter.ts
+++ b/src/cli/doc/filter.ts
@@ -24,6 +24,7 @@ const conditionLine = (condition: FilterCondition): string => {
     case "HasVideo":      return `${prefix}include video`;
     case "HasLinks":      return `${prefix}include links`;
     case "HasMedia":      return `${prefix}include media`;
+    case "HasEmbed":      return `${prefix}include embeds`;
     case "Language":      return `${prefix}be in: ${condition.value}`;
     case "Regex":         return `${prefix}match regex: ${condition.value}`;
     case "DateRange":     return `${prefix}be in date range: ${condition.value}`;

--- a/src/cli/doc/thread.ts
+++ b/src/cli/doc/thread.ts
@@ -1,12 +1,12 @@
 import * as Doc from "@effect/printer/Doc";
 import type { Annotation } from "./annotation.js";
 import { renderTree } from "./tree.js";
-import { renderPostCompact, renderPostCard } from "./post.js";
+import { renderPostCompact, renderPostCardLines } from "./post.js";
 import type { Post } from "../../domain/post.js";
 
 export const renderThread = (
   posts: ReadonlyArray<Post>,
-  options?: { compact?: boolean }
+  options?: { compact?: boolean; lineWidth?: number }
 ): Doc.Doc<Annotation> => {
   const byUri = new Map(posts.map((p) => [String(p.uri), p]));
   const childMap = new Map<string, Post[]>();
@@ -31,7 +31,9 @@ export const renderThread = (
   sortPosts(roots);
   for (const children of childMap.values()) sortPosts(children);
 
-  const render = options?.compact ? renderPostCompact : renderPostCard;
+  const render = options?.compact
+    ? renderPostCompact
+    : (post: Post) => renderPostCardLines(post, { lineWidth: options?.lineWidth });
 
   return renderTree<Post, undefined>(roots, {
     children: (post) =>

--- a/src/cli/filter-dsl.ts
+++ b/src/cli/filter-dsl.ts
@@ -803,6 +803,9 @@ class Parser {
       if (lower === "hasmedia" || lower === "media") {
         return { _tag: "HasMedia" };
       }
+      if (lower === "hasembed" || lower === "embed" || lower === "embeds") {
+        return { _tag: "HasEmbed" };
+      }
       if (lower === "haslinks") {
         return { _tag: "HasLinks" };
       }
@@ -874,7 +877,8 @@ class Parser {
       const baseValue = stripQuotes(baseValueRaw);
 
       switch (key) {
-        case "author": {
+        case "author":
+        case "from": {
           if (baseValue.length === 0) {
             return yield* self.fail(`Missing value for "${key}".`, token.position);
           }
@@ -934,6 +938,30 @@ class Parser {
                 `Unknown post type "${baseValue}".`,
                 token.position
               );
+          }
+        }
+        case "has": {
+          if (baseValue.length === 0) {
+            return yield* self.fail(`Missing value for "${key}".`, token.position);
+          }
+          yield* ensureNoUnknownOptions(options, self.input);
+          switch (baseValue.toLowerCase()) {
+            case "images":
+            case "image":
+              return { _tag: "HasImages" };
+            case "video":
+            case "videos":
+              return { _tag: "HasVideo" };
+            case "links":
+            case "link":
+              return { _tag: "HasLinks" };
+            case "media":
+              return { _tag: "HasMedia" };
+            case "embed":
+            case "embeds":
+              return { _tag: "HasEmbed" };
+            default:
+              return yield* self.fail(`Unknown has: filter "${baseValue}".`, token.position);
           }
         }
         case "engagement": {

--- a/src/cli/filter-errors.ts
+++ b/src/cli/filter-errors.ts
@@ -22,6 +22,7 @@ const validFilterTags = [
   "HasVideo",
   "HasLinks",
   "HasMedia",
+  "HasEmbed",
   "Language",
   "Regex",
   "DateRange",

--- a/src/cli/filter-help.ts
+++ b/src/cli/filter-help.ts
@@ -9,6 +9,7 @@ const filterJsonExamples = [
   "  Is reply:        '{\"_tag\":\"IsReply\"}'",
   "  Engagement:      '{\"_tag\":\"Engagement\",\"minLikes\":100}'",
   "  Has media:       '{\"_tag\":\"HasMedia\"}'",
+  "  Has embed:       '{\"_tag\":\"HasEmbed\"}'",
   "  Language:        '{\"_tag\":\"Language\",\"langs\":[\"en\",\"es\"]}'",
   "  By regex:        '{\"_tag\":\"Regex\",\"patterns\":[\"pattern\"],\"flags\":\"i\"}'",
   "  Trending tag:    '{\"_tag\":\"Trending\",\"tag\":\"#ai\",\"onError\":{\"_tag\":\"Include\"}}'",
@@ -38,12 +39,23 @@ const filterDslExamples = [
   "  is:reply",
   "  engagement:minLikes=100,minReplies=5",
   "  hasmedia",
+  "  hasembed",
   "  language:en,es",
   "  @tech AND author:user.bsky.social",
   "  date:2024-01-01T00:00:00Z..2024-01-31T00:00:00Z",
   "  links:onError=exclude",
   "  trending:#ai,onError=include",
-  "  (hashtag:#ai OR hashtag:#ml) AND author:user.bsky.social"
+  "  (hashtag:#ai OR hashtag:#ml) AND author:user.bsky.social",
+  "",
+  "Aliases:",
+  "  from:alice.bsky.social        -> author:alice.bsky.social",
+  "  tag:#ai                       -> hashtag:#ai",
+  "  text:\"hello\"                 -> contains:\"hello\"",
+  "  lang:en                       -> language:en",
+  "  authors:alice,bob             -> authorin:alice,bob",
+  "  tags:#ai,#ml                  -> hashtagin:#ai,#ml",
+  "  is:reply|quote|repost|original",
+  "  has:images|video|links|media|embed"
 ].join("\n");
 
 export const filterDslDescription = () =>

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -67,7 +67,7 @@ const widthOption = Options.integer("width").pipe(
 );
 const fieldsOption = Options.text("fields").pipe(
   Options.withDescription(
-    "Comma-separated fields to include (supports dot notation and presets: @minimal, @social, @full)"
+    "Comma-separated fields to include (supports dot notation and presets: @minimal, @social, @full). Use author or authorProfile.handle for handles."
   ),
   Options.optional
 );
@@ -316,7 +316,7 @@ export const queryCommand = Command.make(
           yield* writeText(renderPostsTable(posts));
           return;
         case "thread": {
-          const doc = renderThread(posts, { compact: false });
+          const doc = renderThread(posts, { compact: false, lineWidth: w });
           yield* writeText(ansi ? renderAnsi(doc, w) : renderPlain(doc, w));
           return;
         }

--- a/src/cli/view-thread.ts
+++ b/src/cli/view-thread.ts
@@ -117,7 +117,7 @@ export const threadCommand = Command.make(
         return;
       }
 
-      const doc = renderThread(posts, { compact });
+      const doc = renderThread(posts, { compact, lineWidth: w });
       yield* writeText(ansi ? renderAnsi(doc, w) : renderPlain(doc, w));
     })
 ).pipe(

--- a/src/db/migrations/store-index/006_has_embed.ts
+++ b/src/db/migrations/store-index/006_has_embed.ts
@@ -1,0 +1,10 @@
+import * as SqlClient from "@effect/sql/SqlClient";
+import { Effect } from "effect";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`ALTER TABLE posts ADD COLUMN has_embed INTEGER NOT NULL DEFAULT 0`;
+  yield* sql`UPDATE posts SET has_embed = CASE WHEN has_media = 1 OR is_quote = 1 THEN 1 ELSE 0 END`;
+  yield* sql`CREATE INDEX IF NOT EXISTS posts_has_embed_idx ON posts(has_embed)`;
+});

--- a/src/domain/filter.ts
+++ b/src/domain/filter.ts
@@ -239,6 +239,13 @@ export interface FilterHasMedia {
 }
 
 /**
+ * Filter posts containing any embed (media, records, or external links).
+ */
+export interface FilterHasEmbed {
+  readonly _tag: "HasEmbed";
+}
+
+/**
  * Filter posts by language codes.
  *
  * Matches posts that have any of the specified languages in their `langs` field.
@@ -366,6 +373,7 @@ export type FilterExpr =
   | FilterHasVideo
   | FilterHasLinks
   | FilterHasMedia
+  | FilterHasEmbed
   | FilterLanguage
   | FilterRegex
   | FilterDateRange
@@ -443,6 +451,9 @@ interface FilterHasLinksEncoded {
 interface FilterHasMediaEncoded {
   readonly _tag: "HasMedia";
 }
+interface FilterHasEmbedEncoded {
+  readonly _tag: "HasEmbed";
+}
 interface FilterLanguageEncoded {
   readonly _tag: "Language";
   readonly langs: ReadonlyArray<string>;
@@ -488,6 +499,7 @@ type FilterExprEncoded =
   | FilterHasVideoEncoded
   | FilterHasLinksEncoded
   | FilterHasMediaEncoded
+  | FilterHasEmbedEncoded
   | FilterLanguageEncoded
   | FilterRegexEncoded
   | FilterDateRangeEncoded
@@ -584,6 +596,10 @@ const FilterHasMediaSchema: Schema.Schema<FilterHasMedia, FilterHasMediaEncoded,
   "HasMedia",
   {}
 );
+const FilterHasEmbedSchema: Schema.Schema<FilterHasEmbed, FilterHasEmbedEncoded, never> = Schema.TaggedStruct(
+  "HasEmbed",
+  {}
+);
 const LanguageList = Schema.Array(Schema.NonEmptyString).pipe(Schema.minItems(1));
 const FilterLanguageSchema: Schema.Schema<FilterLanguage, FilterLanguageEncoded, never> = Schema.TaggedStruct(
   "Language",
@@ -661,6 +677,7 @@ const FilterExprInternal: Schema.Schema<FilterExpr, FilterExprEncoded, never> = 
   FilterHasVideoSchema,
   FilterHasLinksSchema,
   FilterHasMediaSchema,
+  FilterHasEmbedSchema,
   FilterLanguageSchema,
   FilterRegexSchema,
   FilterDateRangeSchema,

--- a/src/services/filter-compiler.ts
+++ b/src/services/filter-compiler.ts
@@ -129,6 +129,7 @@ const validateExpr: (expr: FilterExpr) => Effect.Effect<void, FilterCompileError
       case "HasVideo":
       case "HasLinks":
       case "HasMedia":
+      case "HasEmbed":
         return;
       case "Language":
         if (expr.langs.length === 0) {
@@ -179,7 +180,7 @@ const validateExpr: (expr: FilterExpr) => Effect.Effect<void, FilterCompileError
  * **Supported Filter Types:**
  * - Basic: All, None, Author, Hashtag, Contains, IsReply, IsQuote, IsRepost
  * - Collections: AuthorIn, HashtagIn (require non-empty arrays)
- * - Media: HasImages, HasVideo, HasLinks, HasMedia
+ * - Media: HasImages, HasVideo, HasLinks, HasMedia, HasEmbed
  * - Metadata: Language (requires langs array), Engagement (requires at least one threshold)
  * - Time: DateRange (start must be before end)
  * - Text: Regex (validates pattern syntax)

--- a/src/services/filter-runtime.ts
+++ b/src/services/filter-runtime.ts
@@ -22,7 +22,7 @@
  * - `Hashtag`, `HashtagIn`: Match by hashtag
  * - `Contains`: Text substring matching
  * - `IsReply`, `IsQuote`, `IsRepost`, `IsOriginal`: Post type matching
- * - `HasImages`, `HasVideo`, `HasLinks`, `HasMedia`: Media detection
+ * - `HasImages`, `HasVideo`, `HasLinks`, `HasMedia`, `HasEmbed`: Media detection
  * - `Engagement`: Threshold-based engagement matching
  * - `Language`: Language code matching
  * - `Regex`: Regular expression pattern matching
@@ -137,6 +137,9 @@ const hasVideo = (post: Post) => {
 
 const hasMedia = (post: Post) =>
   hasImages(post) || hasVideo(post) || hasExternalLink(post);
+
+const hasEmbed = (post: Post) =>
+  post.embed != null || post.recordEmbed != null;
 
 const isRepost = (post: Post) => {
   const reason = post.feed?.reason;
@@ -361,6 +364,13 @@ const buildExplanation = (
             _tag: "HasMedia",
             ok: hasMedia(post),
             detail: `hasMedia=${hasMedia(post)}`
+          });
+      case "HasEmbed":
+        return (post: Post) =>
+          Effect.succeed({
+            _tag: "HasEmbed",
+            ok: hasEmbed(post),
+            detail: `hasEmbed=${hasEmbed(post)}`
           });
       case "Language": {
         const langs = new Set(expr.langs.map((lang) => lang.toLowerCase()));
@@ -597,6 +607,8 @@ const buildPredicate = (
           Effect.succeed(hasExternalLink(post));
       case "HasMedia":
         return (post: Post) => Effect.succeed(hasMedia(post));
+      case "HasEmbed":
+        return (post: Post) => Effect.succeed(hasEmbed(post));
       case "Language": {
         const langs = new Set(expr.langs.map((lang) => lang.toLowerCase()));
         return (post: Post) => {

--- a/src/services/store-index-sql.ts
+++ b/src/services/store-index-sql.ts
@@ -69,6 +69,9 @@ const hasVideo = (post: Post) => {
 const hasMedia = (post: Post) =>
   hasImages(post) || hasVideo(post) || hasExternalLink(post);
 
+const hasEmbed = (post: Post) =>
+  post.embed != null || post.recordEmbed != null;
+
 const normalizeLangs = (langs: ReadonlyArray<string> | undefined) =>
   Array.from(
     new Set(
@@ -112,6 +115,7 @@ export const upsertPost = (
     const images = hasImages(post);
     const video = hasVideo(post);
     const media = hasMedia(post);
+    const embed = hasEmbed(post);
     const metrics = post.metrics;
     const likeCount = metrics?.likeCount ?? 0;
     const repostCount = metrics?.repostCount ?? 0;
@@ -130,6 +134,7 @@ export const upsertPost = (
         is_original,
         has_links,
         has_media,
+        has_embed,
         has_images,
         has_video,
         like_count,
@@ -150,6 +155,7 @@ export const upsertPost = (
         ${toFlag(original)},
         ${toFlag(links)},
         ${toFlag(media)},
+        ${toFlag(embed)},
         ${toFlag(images)},
         ${toFlag(video)},
         ${likeCount},
@@ -169,6 +175,7 @@ export const upsertPost = (
         is_original = excluded.is_original,
         has_links = excluded.has_links,
         has_media = excluded.has_media,
+        has_embed = excluded.has_embed,
         has_images = excluded.has_images,
         has_video = excluded.has_video,
         like_count = excluded.like_count,
@@ -209,6 +216,7 @@ export const insertPostIfMissing = (
     const images = hasImages(post);
     const video = hasVideo(post);
     const media = hasMedia(post);
+    const embed = hasEmbed(post);
     const metrics = post.metrics;
     const likeCount = metrics?.likeCount ?? 0;
     const repostCount = metrics?.repostCount ?? 0;
@@ -227,6 +235,7 @@ export const insertPostIfMissing = (
         is_original,
         has_links,
         has_media,
+        has_embed,
         has_images,
         has_video,
         like_count,
@@ -247,6 +256,7 @@ export const insertPostIfMissing = (
         ${toFlag(original)},
         ${toFlag(links)},
         ${toFlag(media)},
+        ${toFlag(embed)},
         ${toFlag(images)},
         ${toFlag(video)},
         ${likeCount},

--- a/src/services/store-index.ts
+++ b/src/services/store-index.ts
@@ -33,7 +33,7 @@
  * - **Content filters**: Hashtag, HashtagIn, Contains (text search)
  * - **Temporal filters**: DateRange (created_at bounds)
  * - **Post type filters**: IsReply, IsQuote, IsRepost, IsOriginal
- * - **Media filters**: HasLinks, HasMedia, HasImages, HasVideo
+ * - **Media filters**: HasLinks, HasMedia, HasEmbed, HasImages, HasVideo
  * - **Language filters**: Language (post language matching)
  * - **Engagement filters**: Engagement (min likes/reposts/replies)
  *
@@ -175,6 +175,8 @@ type PushdownExpr =
   | { readonly _tag: "HasLinks" }
   /** Filter for posts with any media */
   | { readonly _tag: "HasMedia" }
+  /** Filter for posts with any embed */
+  | { readonly _tag: "HasEmbed" }
   /** Filter for posts with images */
   | { readonly _tag: "HasImages" }
   /** Filter for posts with video */
@@ -276,6 +278,8 @@ const buildPushdown = (expr: FilterExpr | undefined): PushdownExpr => {
       return { _tag: "HasLinks" };
     case "HasMedia":
       return { _tag: "HasMedia" };
+    case "HasEmbed":
+      return { _tag: "HasEmbed" };
     case "HasImages":
       return { _tag: "HasImages" };
     case "HasVideo":
@@ -351,6 +355,8 @@ const pushdownToSql = (
       return sql`p.has_links = 1`;
     case "HasMedia":
       return sql`p.has_media = 1`;
+    case "HasEmbed":
+      return sql`p.has_embed = 1`;
     case "HasImages":
       return sql`p.has_images = 1`;
     case "HasVideo":


### PR DESCRIPTION
## Summary
- avoid Doc.reflow in thread tree rendering to prevent hangs on large threads
- add hasembed filter + pushdown + migration
- improve filter DSL aliases/description and negation phrasing
- validate fields dot-paths and trim Bsky API error verbosity

## Testing
- not run (not requested)

Fixes #65
Fixes #66
Fixes #67
Fixes #69
Fixes #70
Fixes #71