### PR TITLE
feat(cli): add pipe command for NDJSON filtering

### DIFF
--- a/src/cli/app.ts
+++ b/src/cli/app.ts
@@ -17,6 +17,7 @@ import { searchCommand } from "./search.js";
 import { graphCommand } from "./graph.js";
 import { feedCommand } from "./feed.js";
 import { postCommand } from "./post.js";
+import { pipeCommand } from "./pipe.js";
 import { configCommand } from "./config-command.js";
 import {
   configOptions,
@@ -39,7 +40,8 @@ export const app = Command.make("skygent", configOptions).pipe(
     searchCommand,
     graphCommand,
     feedCommand,
-    postCommand
+    postCommand,
+    pipeCommand
   ]),
   Command.provide((config) =>
     Layer.mergeAll(

--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -1,0 +1,45 @@
+import { SystemError, type PlatformError } from "@effect/platform/Error";
+import { Context, Effect, Layer, Stream } from "effect";
+import { createInterface } from "node:readline";
+
+export interface CliInputService {
+  readonly lines: Stream.Stream<string, PlatformError>;
+}
+
+const makeLines = () =>
+  Stream.unwrapScoped(
+    Effect.acquireRelease(
+      Effect.sync(() =>
+        createInterface({
+          input: process.stdin,
+          crlfDelay: Infinity
+        })
+      ),
+      (rl) => Effect.sync(() => rl.close())
+    ).pipe(
+      Effect.map((rl) =>
+        Stream.fromAsyncIterable(
+          rl,
+          (cause) =>
+            new SystemError({
+              module: "Stream",
+              method: "stdin",
+              reason: "Unknown",
+              cause
+            })
+        )
+      )
+    )
+  );
+
+export class CliInput extends Context.Tag("@skygent/CliInput")<
+  CliInput,
+  CliInputService
+>() {
+  static readonly layer = Layer.succeed(
+    CliInput,
+    CliInput.of({
+      lines: makeLines()
+    })
+  );
+}

--- a/src/cli/layers.ts
+++ b/src/cli/layers.ts
@@ -22,6 +22,7 @@ import { LinkValidator } from "../services/link-validator.js";
 import { TrendingTopics } from "../services/trending-topics.js";
 import { ResourceMonitor } from "../services/resource-monitor.js";
 import { CliOutput } from "./output.js";
+import { CliInput } from "./input.js";
 import { DerivationEngine } from "../services/derivation-engine.js";
 import { DerivationValidator } from "../services/derivation-validator.js";
 import { DerivationSettings } from "../services/derivation-settings.js";
@@ -157,6 +158,7 @@ export const CliLive = Layer.mergeAll(
   appConfigLayer,
   filterSettingsLayer,
   credentialLayer,
+  CliInput.layer,
   CliOutput.layer,
   resourceMonitorLayer,
   managerLayer,

--- a/src/cli/pipe.ts
+++ b/src/cli/pipe.ts
@@ -1,0 +1,157 @@
+import { Command, Options } from "@effect/cli";
+import { Chunk, Effect, Option, Ref, Stream } from "effect";
+import { ParseResult } from "effect";
+import { RawPost } from "../domain/raw.js";
+import type { Post } from "../domain/post.js";
+import { FilterRuntime } from "../services/filter-runtime.js";
+import { PostParser } from "../services/post-parser.js";
+import { CliInput } from "./input.js";
+import { CliInputError, CliJsonError } from "./errors.js";
+import { parseFilterExpr } from "./filter-input.js";
+import { decodeJson } from "./parse.js";
+import { withExamples } from "./help.js";
+import { filterOption, filterJsonOption } from "./shared-options.js";
+import { formatSchemaError } from "./shared.js";
+import { writeJsonStream, writeText } from "./output.js";
+import { filterByFlags } from "../typeclass/chunk.js";
+import { logErrorEvent, logWarn } from "./logging.js";
+
+const onErrorOption = Options.choice("on-error", ["fail", "skip", "report"]).pipe(
+  Options.withDescription("Behavior on invalid input lines"),
+  Options.withDefault("fail" as const)
+);
+
+const batchSizeOption = Options.integer("batch-size").pipe(
+  Options.withDescription("Posts per filter batch (default: 50)"),
+  Options.optional
+);
+
+const requireFilterExpr = (
+  filter: Option.Option<string>,
+  filterJson: Option.Option<string>
+) =>
+  Option.isNone(filter) && Option.isNone(filterJson)
+    ? Effect.fail(
+        CliInputError.make({
+          message: "Provide --filter or --filter-json.",
+          cause: { filter: null, filterJson: null }
+        })
+      )
+    : Effect.void;
+
+const truncate = (value: string, max = 500) =>
+  value.length > max ? `${value.slice(0, max)}...` : value;
+
+const formatPipeError = (error: unknown) => {
+  if (error instanceof CliJsonError || error instanceof CliInputError) {
+    return error.message;
+  }
+  if (ParseResult.isParseError(error)) {
+    return formatSchemaError(error);
+  }
+  if (typeof error === "object" && error !== null && "message" in error) {
+    const message = (error as { readonly message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+  return String(error);
+};
+
+export const pipeCommand = Command.make(
+  "pipe",
+  { filter: filterOption, filterJson: filterJsonOption, onError: onErrorOption, batchSize: batchSizeOption },
+  ({ filter, filterJson, onError, batchSize }) =>
+    Effect.gen(function* () {
+      if (process.stdin.isTTY) {
+        return yield* CliInputError.make({
+          message: "stdin is a TTY. Pipe NDJSON input into skygent pipe.",
+          cause: { isTTY: true }
+        });
+      }
+      yield* requireFilterExpr(filter, filterJson);
+
+      const input = yield* CliInput;
+      const parser = yield* PostParser;
+      const runtime = yield* FilterRuntime;
+      const expr = yield* parseFilterExpr(filter, filterJson);
+      const evaluateBatch = yield* runtime.evaluateBatch(expr);
+
+      const size = Option.getOrElse(batchSize, () => 50);
+      if (size <= 0) {
+        return yield* CliInputError.make({
+          message: "--batch-size must be a positive integer.",
+          cause: { batchSize: size }
+        });
+      }
+
+      const lineRef = yield* Ref.make(0);
+      const countRef = yield* Ref.make(0);
+
+      const parsed = input.lines.pipe(
+        Stream.map((line) => line.trim()),
+        Stream.filter((line) => line.length > 0),
+        Stream.mapEffect((line) =>
+          Ref.updateAndGet(lineRef, (value) => value + 1).pipe(
+            Effect.map((lineNumber) => ({ line, lineNumber }))
+          )
+        ),
+        Stream.mapEffect(({ line, lineNumber }) =>
+          decodeJson(RawPost, line).pipe(
+            Effect.flatMap((raw) => parser.parsePost(raw)),
+            Effect.map(Option.some),
+            Effect.catchAll((error) => {
+              if (onError === "fail") {
+                return Effect.fail(error);
+              }
+              const message = formatPipeError(error);
+              const payload = {
+                line: lineNumber,
+                message,
+                input: truncate(line)
+              };
+              const log =
+                onError === "report"
+                  ? logErrorEvent("Invalid input line", payload)
+                  : logWarn("Skipping invalid input line", payload);
+              return log.pipe(
+                Effect.ignore,
+                Effect.as(Option.none<Post>())
+              );
+            })
+          )
+        ),
+        Stream.filterMap((value) => value)
+      );
+
+      const filtered = parsed.pipe(
+        Stream.grouped(size),
+        Stream.mapEffect((batch) =>
+          evaluateBatch(batch).pipe(
+            Effect.map((flags) => filterByFlags(batch, flags))
+          )
+        ),
+        Stream.mapConcat((chunk) => Chunk.toReadonlyArray(chunk)),
+        Stream.tap(() => Ref.update(countRef, (count) => count + 1))
+      );
+
+      yield* writeJsonStream(filtered);
+      const count = yield* Ref.get(countRef);
+      if (count === 0) {
+        yield* writeText("[]");
+      }
+    })
+).pipe(
+  Command.withDescription(
+    withExamples(
+      "Filter raw post NDJSON from stdin",
+      [
+        "skygent pipe --filter 'hashtag:#ai' < posts.ndjson",
+        "cat posts.ndjson | skygent pipe --filter-json '{\"_tag\":\"All\"}'"
+      ],
+      [
+        "Note: stdin must be raw post NDJSON (app.bsky.feed.getPosts result)."
+      ]
+    )
+  )
+);

--- a/tests/cli/pipe.test.ts
+++ b/tests/cli/pipe.test.ts
@@ -1,0 +1,201 @@
+import { Command } from "@effect/cli";
+import { describe, expect, test } from "bun:test";
+import { Chunk, Clock, Effect, Layer, Ref, Sink, Stream } from "effect";
+import { CliInput, type CliInputService } from "../../src/cli/input.js";
+import { CliOutput, type CliOutputService } from "../../src/cli/output.js";
+import { pipeCommand } from "../../src/cli/pipe.js";
+import { FilterRuntime } from "../../src/services/filter-runtime.js";
+import { FilterLibrary } from "../../src/services/filter-library.js";
+import { FilterNotFound } from "../../src/domain/errors.js";
+import { PostParser } from "../../src/services/post-parser.js";
+import type { FilterExpr } from "../../src/domain/filter.js";
+import type { Post } from "../../src/domain/post.js";
+
+const ensureNewline = (value: string) => (value.endsWith("\n") ? value : `${value}\n`);
+
+const decodeChunk = (chunk: string | Uint8Array) =>
+  typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+
+const makeOutputCapture = () => {
+  const stdoutRef = Ref.unsafeMake<ReadonlyArray<string>>([]);
+  const stderrRef = Ref.unsafeMake<ReadonlyArray<string>>([]);
+
+  const append = (ref: Ref.Ref<ReadonlyArray<string>>, chunk: string | Uint8Array) =>
+    Ref.update(ref, (items) => [...items, decodeChunk(chunk)]);
+
+  const stdoutSink = Sink.forEach((chunk: string | Uint8Array) =>
+    append(stdoutRef, chunk)
+  );
+  const stderrSink = Sink.forEach((chunk: string | Uint8Array) =>
+    append(stderrRef, chunk)
+  );
+
+  const writeJson = (value: unknown, pretty?: boolean) =>
+    append(
+      stdoutRef,
+      ensureNewline(JSON.stringify(value, null, pretty ? 2 : 0))
+    );
+
+  const writeText = (value: string) =>
+    append(stdoutRef, ensureNewline(value));
+
+  const writeJsonStream = <A, E, R>(stream: Stream.Stream<A, E, R>) =>
+    stream.pipe(
+      Stream.map((value) => `${JSON.stringify(value)}\n`),
+      Stream.run(stdoutSink)
+    );
+
+  const writeStderr = (value: string) =>
+    append(stderrRef, ensureNewline(value));
+
+  const service: CliOutputService = {
+    stdout: stdoutSink,
+    stderr: stderrSink,
+    writeJson,
+    writeText,
+    writeJsonStream,
+    writeStderr
+  };
+
+  const layer = Layer.succeed(CliOutput, CliOutput.of(service));
+
+  return { layer, stdoutRef, stderrRef };
+};
+
+const makeInputLayer = (lines: ReadonlyArray<string>) => {
+  const service: CliInputService = {
+    lines: Stream.fromIterable(lines)
+  };
+  return Layer.succeed(CliInput, CliInput.of(service));
+};
+
+const matches = (expr: FilterExpr, post: Post) => {
+  switch (expr._tag) {
+    case "Contains": {
+      const target = expr.caseSensitive ? post.text : post.text.toLowerCase();
+      const needle = expr.caseSensitive ? expr.text : expr.text.toLowerCase();
+      return target.includes(needle);
+    }
+    case "All":
+      return true;
+    default:
+      return true;
+  }
+};
+
+const runtimeLayer = Layer.succeed(
+  FilterRuntime,
+  FilterRuntime.of({
+    evaluate: (expr) =>
+      Effect.succeed((post) => Effect.succeed(matches(expr, post))),
+    evaluateWithMetadata: (expr) =>
+      Effect.succeed((post) => Effect.succeed({ ok: matches(expr, post) })),
+    evaluateBatch: (expr) =>
+      Effect.succeed((posts) =>
+        Effect.succeed(Chunk.map(posts, (post) => matches(expr, post)))
+      ),
+    explain: () => Effect.die("not implemented")
+  })
+);
+
+const libraryLayer = Layer.succeed(
+  FilterLibrary,
+  FilterLibrary.of({
+    list: () => Effect.succeed([]),
+    get: (name) => Effect.fail(FilterNotFound.make({ name })),
+    save: () => Effect.void,
+    remove: () => Effect.void,
+    validateAll: () => Effect.succeed([])
+  })
+);
+
+const clockLayer = Layer.succeed(Clock.Clock, Clock.make());
+
+const makeRawPost = (text: string, uri: string) => ({
+  uri,
+  author: "alice.bsky.social",
+  record: {
+    text,
+    createdAt: "2026-01-01T00:00:00Z"
+  }
+});
+
+describe("pipe command", () => {
+  test("filters raw posts from stdin and outputs matches", async () => {
+    const run = Command.run(pipeCommand, { name: "skygent", version: "0.0.0" });
+    const { layer: outputLayer, stdoutRef, stderrRef } = makeOutputCapture();
+    const inputLines = [
+      JSON.stringify(makeRawPost("match me", "at://did:plc:1/app.bsky.feed.post/1")),
+      JSON.stringify(makeRawPost("skip me", "at://did:plc:2/app.bsky.feed.post/2"))
+    ];
+    const inputLayer = makeInputLayer(inputLines);
+    const appLayer = Layer.mergeAll(
+      outputLayer,
+      inputLayer,
+      runtimeLayer,
+      libraryLayer,
+      PostParser.layer,
+      clockLayer
+    );
+
+    await Effect.runPromise(
+      run([
+        "node",
+        "skygent",
+        "--filter-json",
+        JSON.stringify({ _tag: "Contains", text: "match" })
+      ]).pipe(Effect.provide(appLayer))
+    );
+
+    const stdout = await Effect.runPromise(Ref.get(stdoutRef));
+    const stderr = await Effect.runPromise(Ref.get(stderrRef));
+
+    expect(stderr.length).toBe(0);
+    const payloads = stdout
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line));
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({ text: "match me" });
+  });
+
+  test("skips invalid input lines when on-error=skip", async () => {
+    const run = Command.run(pipeCommand, { name: "skygent", version: "0.0.0" });
+    const { layer: outputLayer, stdoutRef, stderrRef } = makeOutputCapture();
+    const inputLines = [
+      JSON.stringify(makeRawPost("first", "at://did:plc:3/app.bsky.feed.post/3")),
+      "{invalid-json",
+      JSON.stringify(makeRawPost("second", "at://did:plc:4/app.bsky.feed.post/4"))
+    ];
+    const inputLayer = makeInputLayer(inputLines);
+    const appLayer = Layer.mergeAll(
+      outputLayer,
+      inputLayer,
+      runtimeLayer,
+      libraryLayer,
+      PostParser.layer,
+      clockLayer
+    );
+
+    await Effect.runPromise(
+      run([
+        "node",
+        "skygent",
+        "--filter-json",
+        JSON.stringify({ _tag: "All" }),
+        "--on-error",
+        "skip"
+      ]).pipe(Effect.provide(appLayer))
+    );
+
+    const stdout = await Effect.runPromise(Ref.get(stdoutRef));
+    const stderr = await Effect.runPromise(Ref.get(stderrRef));
+
+    const payloads = stdout
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line));
+    expect(payloads).toHaveLength(2);
+    expect(stderr.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary\n- add CLI input service for streaming stdin lines\n- introduce `skygent pipe` for NDJSON filtering with error handling and batching\n- add pipe command tests covering filtering and skip-on-error\n\n## Testing\n- bun run typecheck\n- bun test