### PR TITLE
fix(cli): improve config errors and jetstream warnings

### DIFF
--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -132,5 +132,13 @@ export const makeSyncReporter = (
             { discard: true }
           );
         }
+      }).pipe(Effect.orElseSucceed(() => undefined)),
+    warn: (message, data) =>
+      Effect.gen(function* () {
+        const format = yield* resolveLogFormat;
+        yield* logEventWith(output, format, "WARN", {
+          message,
+          ...data
+        });
       }).pipe(Effect.orElseSucceed(() => undefined))
   });

--- a/src/cli/store.ts
+++ b/src/cli/store.ts
@@ -14,7 +14,7 @@ import { StoreCleaner } from "../services/store-cleaner.js";
 import { LineageStore } from "../services/lineage-store.js";
 import { CliInputError } from "./errors.js";
 import { OutputManager } from "../services/output-manager.js";
-import { formatStoreConfigParseError } from "./store-errors.js";
+import { formatStoreConfigHelp, formatStoreConfigParseError } from "./store-errors.js";
 import { formatFilterExpr } from "../domain/filter-describe.js";
 import { CliPreferences } from "./preferences.js";
 import { StoreStats } from "../services/store-stats.js";
@@ -267,7 +267,9 @@ export const storeMaterialize = Command.make(
 
       if (config.filters.length === 0) {
         return yield* CliInputError.make({
-          message: `Store "${name}" has no configured filters to materialize. Update the store config to add filters.`,
+          message: formatStoreConfigHelp(
+            `Store "${name}" has no configured filters to materialize. Add filters to the store config.`
+          ),
           cause: { store: name }
         });
       }

--- a/src/services/jetstream-sync.ts
+++ b/src/services/jetstream-sync.ts
@@ -583,10 +583,10 @@ export class JetstreamSyncEngine extends Context.Tag("@skygent/JetstreamSyncEngi
                 Stream.interruptWhen(
                   Effect.sleep(config.duration).pipe(
                     Effect.zipRight(
-                      Effect.logWarning(
-                        "Jetstream sync exceeded duration; shutting down.",
-                        { durationMs: Duration.toMillis(config.duration) }
-                      )
+                      reporter.warn("Jetstream sync exceeded duration; shutting down.", {
+                        durationMs: Duration.toMillis(config.duration),
+                        store: config.store.name
+                      })
                     ),
                     Effect.zipRight(safeShutdown)
                   )

--- a/src/services/sync-reporter.ts
+++ b/src/services/sync-reporter.ts
@@ -5,12 +5,14 @@ export class SyncReporter extends Context.Tag("@skygent/SyncReporter")<
   SyncReporter,
   {
     readonly report: (progress: SyncProgress) => Effect.Effect<void>;
+    readonly warn: (message: string, data?: Record<string, unknown>) => Effect.Effect<void>;
   }
 >() {
   static readonly layer = Layer.succeed(
     SyncReporter,
     SyncReporter.of({
-      report: () => Effect.void
+      report: () => Effect.void,
+      warn: () => Effect.void
     })
   );
 }


### PR DESCRIPTION
## Summary\n- route jetstream duration warnings through SyncReporter for structured CLI logging\n- enhance store config validation errors with minimal config guidance and doc pointers\n- improve store materialize error when no filters are configured\n\nFixes #87\nFixes #84\nFixes #83\n\n## Testing\n- bun run typecheck\n- bun test