### PR TITLE
feat: add store rename command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ skygent search posts "effect typescript" --store my-store
 | `store create <name>` | Create a new store |
 | `store list` | List all stores |
 | `store show <name>` | Show store config and metadata |
+| `store rename <from> <to>` | Rename a store |
 | `store delete <name> --force` | Delete a store |
 | `store stats <name>` | Show store statistics |
 | `store summary` | Summarize all stores |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,6 +34,7 @@ Manage stores.
 - `store stats <name>`
 - `store summary`
 - `store tree [--format <tree|table|json>] [--ansi] [--width <n>]`
+- `store rename <from> <to>`
 - `store delete <name> --force`
 - `store materialize <name> [--filter <filter-name>]`
 
@@ -46,6 +47,7 @@ bun run index.ts store stats my-store
 bun run index.ts store summary
 bun run index.ts store tree --format table
 bun run index.ts store tree --ansi --width 100
+bun run index.ts store rename old-store new-store
 bun run index.ts store delete my-store --force
 ```
 

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -10,6 +10,8 @@ Store names must match this pattern:
 
 That means lowercase letters or digits, may include `-` or `_`, and must be 2-64 characters.
 
+To rename a store, use `skygent store rename <old> <new>`.
+
 ## Store root layout
 
 The default store root is `~/.skygent`. Contents:

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ import {
 import { logErrorEvent } from "./src/cli/logging.js";
 import { CliOutput } from "./src/cli/output.js";
 import { exitCodeFor, exitCodeFromExit } from "./src/cli/exit-codes.js";
-import { BskyError, StoreNotFound } from "./src/domain/errors.js";
+import { BskyError, StoreAlreadyExists, StoreNotFound } from "./src/domain/errors.js";
 
 const cli = Command.run(app, {
   name: "skygent",
@@ -50,6 +50,9 @@ const formatError = (error: unknown, agentPayload?: AgentErrorPayload) => {
   }
   if (error instanceof StoreNotFound) {
     return `Store \"${error.name}\" does not exist.`;
+  }
+  if (error instanceof StoreAlreadyExists) {
+    return `Store \"${error.name}\" already exists.`;
   }
   if (error instanceof Error) {
     return error.message;
@@ -88,6 +91,9 @@ const errorDetails = (
   if (error instanceof StoreNotFound) {
     return { error: { _tag: "StoreNotFound", name: error.name } };
   }
+  if (error instanceof StoreAlreadyExists) {
+    return { error: { _tag: "StoreAlreadyExists", name: error.name } };
+  }
   if (error instanceof BskyError) {
     return {
       error: {
@@ -113,6 +119,9 @@ const errorSuggestion = (
   if (agentPayload?.fix) return agentPayload.fix;
   if (error instanceof StoreNotFound) {
     return `Run: skygent store create ${error.name}`;
+  }
+  if (error instanceof StoreAlreadyExists) {
+    return "Run: skygent store list";
   }
   return undefined;
 };

--- a/src/cli/exit-codes.ts
+++ b/src/cli/exit-codes.ts
@@ -8,6 +8,7 @@ import {
   FilterEvalError,
   FilterLibraryError,
   FilterNotFound,
+  StoreAlreadyExists,
   StoreIoError,
   StoreIndexError,
   StoreNotFound
@@ -21,6 +22,7 @@ export const exitCodeFor = (error: unknown): number => {
   if (error instanceof CliInputError) return 2;
   if (error instanceof ConfigError) return 2;
   if (error instanceof StoreNotFound) return 3;
+  if (error instanceof StoreAlreadyExists) return 2;
   if (error instanceof FilterNotFound) return 2;
   if (error instanceof FilterLibraryError) return 2;
   if (error instanceof StoreIoError || error instanceof StoreIndexError) return 7;

--- a/src/cli/layers.ts
+++ b/src/cli/layers.ts
@@ -18,6 +18,7 @@ import { SyncCheckpointStore } from "../services/sync-checkpoint-store.js";
 import { SyncReporter } from "../services/sync-reporter.js";
 import { SyncSettings } from "../services/sync-settings.js";
 import { StoreCleaner } from "../services/store-cleaner.js";
+import { StoreRenamer } from "../services/store-renamer.js";
 import { LinkValidator } from "../services/link-validator.js";
 import { TrendingTopics } from "../services/trending-topics.js";
 import { ResourceMonitor } from "../services/resource-monitor.js";
@@ -115,6 +116,12 @@ const viewCheckpointLayer = ViewCheckpointStore.layer.pipe(
 const lineageLayer = LineageStore.layer.pipe(
   Layer.provideMerge(storageLayer)
 );
+const storeRenamerLayer = StoreRenamer.layer.pipe(
+  Layer.provideMerge(appConfigLayer),
+  Layer.provideMerge(managerLayer),
+  Layer.provideMerge(storeDbLayer),
+  Layer.provideMerge(lineageLayer)
+);
 const compilerLayer = FilterCompiler.layer;
 const postParserLayer = PostParser.layer;
 const derivationEngineLayer = DerivationEngine.layer.pipe(
@@ -166,6 +173,7 @@ export const CliLive = Layer.mergeAll(
   indexLayer,
   eventLogLayer,
   cleanerLayer,
+  storeRenamerLayer,
   syncLayer,
   checkpointLayer,
   viewCheckpointLayer,

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -42,6 +42,11 @@ export class StoreNotFound extends Schema.TaggedError<StoreNotFound>()(
   { name: StoreName }
 ) {}
 
+export class StoreAlreadyExists extends Schema.TaggedError<StoreAlreadyExists>()(
+  "StoreAlreadyExists",
+  { name: StoreName }
+) {}
+
 export class StoreIoError extends Schema.TaggedError<StoreIoError>()(
   "StoreIoError",
   { path: StorePath, cause: Schema.Unknown }
@@ -68,4 +73,4 @@ export class FilterLibraryError extends Schema.TaggedError<FilterLibraryError>()
   }
 ) {}
 
-export type StoreError = StoreNotFound | StoreIoError | StoreIndexError;
+export type StoreError = StoreNotFound | StoreAlreadyExists | StoreIoError | StoreIndexError;

--- a/src/services/lineage-store.ts
+++ b/src/services/lineage-store.ts
@@ -63,6 +63,14 @@ export class LineageStore extends Context.Tag("@skygent/LineageStore")<
      * @returns Effect resolving to void, or StoreIoError on failure
      */
     readonly save: (lineage: StoreLineage) => Effect.Effect<void, StoreIoError>;
+
+    /**
+     * Removes lineage information for a store.
+     *
+     * @param storeName - The name of the store to remove lineage for
+     * @returns Effect resolving to void, or StoreIoError on failure
+     */
+    readonly remove: (storeName: StoreName) => Effect.Effect<void, StoreIoError>;
   }
 >() {
   static readonly layer = Layer.effect(
@@ -83,7 +91,13 @@ export class LineageStore extends Context.Tag("@skygent/LineageStore")<
           .pipe(Effect.mapError(toStoreIoError(lineage.storeName)))
       );
 
-      return LineageStore.of({ get, save });
+      const remove = Effect.fn("LineageStore.remove")((storeName: StoreName) =>
+        lineages
+          .remove(lineageKey(storeName))
+          .pipe(Effect.mapError(toStoreIoError(storeName)))
+      );
+
+      return LineageStore.of({ get, save, remove });
     })
   );
 }

--- a/src/services/store-renamer.ts
+++ b/src/services/store-renamer.ts
@@ -1,0 +1,286 @@
+import { FileSystem, Path } from "@effect/platform";
+import { Chunk, Context, Effect, Layer, Option, Ref, Schema } from "effect";
+import { StoreAlreadyExists, StoreIoError, StoreNotFound } from "../domain/errors.js";
+import { StoreLineage, StoreSource } from "../domain/derivation.js";
+import { StoreName, StorePath } from "../domain/primitives.js";
+import { StoreRef } from "../domain/store.js";
+import { AppConfigService } from "./app-config.js";
+import { LineageStore } from "./lineage-store.js";
+import { StoreDb } from "./store-db.js";
+import { StoreManager } from "./store-manager.js";
+
+type StoreRenameResult = {
+  readonly from: StoreName;
+  readonly to: StoreName;
+  readonly moved: boolean;
+  readonly lineagesUpdated: number;
+  readonly checkpointsUpdated: number;
+};
+
+type RenameState = {
+  readonly completed: boolean;
+  readonly dirRenamed: boolean;
+  readonly catalogUpdated: boolean;
+  readonly checkpointsUpdated: boolean;
+  readonly lineagesUpdated: boolean;
+};
+
+const storeRootKey = (name: StoreName) =>
+  Schema.decodeUnknownSync(StorePath)(`stores/${name}`);
+
+const toStoreIoError = (path: StorePath) => (cause: unknown) =>
+  StoreIoError.make({ path, cause });
+
+const toStoreRef = (metadata: { readonly name: StoreName; readonly root: StorePath }) =>
+  StoreRef.make({ name: metadata.name, root: metadata.root });
+
+const renameDirectory = (
+  fs: FileSystem.FileSystem,
+  path: Path.Path,
+  fromPath: string,
+  toPath: string
+) =>
+  Effect.gen(function* () {
+    if (fromPath === toPath) {
+      return;
+    }
+    const normalizedFrom = fromPath.toLowerCase();
+    const normalizedTo = toPath.toLowerCase();
+    if (normalizedFrom === normalizedTo) {
+      const tempName = `.rename-${Date.now()}`;
+      const tempPath = path.join(path.dirname(toPath), tempName);
+      yield* fs.rename(fromPath, tempPath);
+      yield* fs.rename(tempPath, toPath);
+      return;
+    }
+    yield* fs.rename(fromPath, toPath);
+  });
+
+const renameLineage = (
+  lineage: StoreLineage,
+  from: StoreName,
+  to: StoreName
+) => {
+  const nextStoreName = lineage.storeName === from ? to : lineage.storeName;
+  let changed = nextStoreName !== lineage.storeName;
+  const nextSources = lineage.sources.map((source) => {
+    if (source.storeName !== from) {
+      return source;
+    }
+    changed = true;
+    return StoreSource.make({ ...source, storeName: to });
+  });
+  if (!changed) {
+    return Option.none<StoreLineage>();
+  }
+  return Option.some(
+    StoreLineage.make({
+      ...lineage,
+      storeName: nextStoreName,
+      sources: nextSources
+    })
+  );
+};
+
+export class StoreRenamer extends Context.Tag("@skygent/StoreRenamer")<
+  StoreRenamer,
+  {
+    readonly rename: (
+      from: StoreName,
+      to: StoreName
+    ) => Effect.Effect<StoreRenameResult, StoreNotFound | StoreAlreadyExists | StoreIoError>;
+  }
+>() {
+  static readonly layer = Layer.effect(
+    StoreRenamer,
+    Effect.gen(function* () {
+      const manager = yield* StoreManager;
+      const storeDb = yield* StoreDb;
+      const lineageStore = yield* LineageStore;
+      const appConfig = yield* AppConfigService;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const updateLineages = (
+        from: StoreName,
+        to: StoreName,
+        storeNames: ReadonlyArray<StoreName>
+      ) =>
+        Effect.forEach(
+          storeNames,
+          (storeName) =>
+            lineageStore.get(storeName).pipe(
+              Effect.flatMap(
+                Option.match({
+                  onNone: () => Effect.succeed(0),
+                  onSome: (lineage) =>
+                    Option.match(renameLineage(lineage, from, to), {
+                      onNone: () => Effect.succeed(0),
+                      onSome: (updated) =>
+                        Effect.gen(function* () {
+                          yield* lineageStore.save(updated);
+                          if (lineage.storeName === from) {
+                            yield* lineageStore.remove(from);
+                          }
+                          return 1;
+                        })
+                    })
+                })
+              )
+            ),
+          { discard: false }
+        ).pipe(Effect.map((updates) => updates.reduce((sum, value) => sum + value, 0)));
+
+      const updateDerivationCheckpoints = (
+        from: StoreName,
+        to: StoreName,
+        stores: ReadonlyArray<StoreRef>
+      ) =>
+        Effect.forEach(
+          stores,
+          (store) =>
+            storeDb.withClient(store, (client) =>
+              client`UPDATE derivation_checkpoints
+                SET view_name = CASE WHEN view_name = ${from} THEN ${to} ELSE view_name END,
+                    source_store = CASE WHEN source_store = ${from} THEN ${to} ELSE source_store END,
+                    target_store = CASE WHEN target_store = ${from} THEN ${to} ELSE target_store END
+                WHERE view_name = ${from}
+                   OR source_store = ${from}
+                   OR target_store = ${from}`.pipe(Effect.as(1))
+            ).pipe(Effect.mapError(toStoreIoError(store.root))),
+          { discard: false }
+        ).pipe(Effect.map((updates) => updates.reduce((sum, value) => sum + value, 0)));
+
+      const rename = Effect.fn("StoreRenamer.rename")(
+        (from: StoreName, to: StoreName) =>
+          Effect.gen(function* () {
+            const storeOption = yield* manager.getStore(from);
+            if (Option.isNone(storeOption)) {
+              return yield* StoreNotFound.make({ name: from });
+            }
+            const targetOption = yield* manager.getStore(to);
+            if (Option.isSome(targetOption)) {
+              return yield* StoreAlreadyExists.make({ name: to });
+            }
+            const store = storeOption.value;
+            const newRoot = storeRootKey(to);
+            const fromPath = path.join(appConfig.storeRoot, store.root);
+            const toPath = path.join(appConfig.storeRoot, newRoot);
+            const fromExists = yield* fs
+              .exists(fromPath)
+              .pipe(Effect.mapError(toStoreIoError(store.root)));
+            const toExists = yield* fs
+              .exists(toPath)
+              .pipe(Effect.mapError(toStoreIoError(newRoot)));
+            if (toExists) {
+              return yield* StoreAlreadyExists.make({ name: to });
+            }
+
+            const storesBefore = yield* manager.listStores();
+            const storeNamesBefore = Chunk.toReadonlyArray(storesBefore).map(
+              (entry) => entry.name
+            );
+
+            const state = yield* Ref.make<RenameState>({
+              completed: false,
+              dirRenamed: false,
+              catalogUpdated: false,
+              checkpointsUpdated: false,
+              lineagesUpdated: false
+            });
+
+            const rollback = (status: RenameState) =>
+              status.completed
+                ? Effect.void
+                : Effect.gen(function* () {
+                    if (status.lineagesUpdated) {
+                      const stores = yield* manager.listStores();
+                      const storeNames = Chunk.toReadonlyArray(stores).map(
+                        (entry) => entry.name
+                      );
+                      yield* updateLineages(to, from, storeNames).pipe(
+                        Effect.catchAll(() => Effect.void)
+                      );
+                    }
+                    if (status.checkpointsUpdated) {
+                      const stores = yield* manager.listStores();
+                      const storeRefs = Chunk.toReadonlyArray(stores).map(toStoreRef);
+                      yield* updateDerivationCheckpoints(to, from, storeRefs).pipe(
+                        Effect.catchAll(() => Effect.void)
+                      );
+                    }
+                    if (status.dirRenamed) {
+                      yield* storeDb.removeClient(to);
+                      yield* renameDirectory(fs, path, toPath, fromPath).pipe(
+                        Effect.catchAll(() => Effect.void)
+                      );
+                    }
+                    if (status.catalogUpdated) {
+                      yield* manager.renameStore(to, from).pipe(
+                        Effect.catchAll(() => Effect.void)
+                      );
+                    }
+                  });
+
+            const program = Effect.gen(function* () {
+              yield* storeDb.removeClient(from);
+
+              if (fromExists) {
+                yield* renameDirectory(fs, path, fromPath, toPath).pipe(
+                  Effect.mapError(toStoreIoError(store.root))
+                );
+                yield* Ref.update(state, (current) => ({ ...current, dirRenamed: true }));
+              }
+
+              yield* manager.renameStore(from, to);
+              yield* Ref.update(state, (current) => ({
+                ...current,
+                catalogUpdated: true
+              }));
+
+              const storesAfter = yield* manager.listStores();
+              const storeRefsAfter = Chunk.toReadonlyArray(storesAfter).map(toStoreRef);
+
+              const checkpointsUpdated = yield* updateDerivationCheckpoints(
+                from,
+                to,
+                storeRefsAfter
+              );
+              yield* Ref.update(state, (current) => ({
+                ...current,
+                checkpointsUpdated: true
+              }));
+
+              const lineagesUpdated = yield* updateLineages(from, to, storeNamesBefore);
+              yield* Ref.update(state, (current) => ({
+                ...current,
+                lineagesUpdated: true
+              }));
+
+              yield* Ref.update(state, (current) => ({ ...current, completed: true }));
+
+              return {
+                from,
+                to,
+                moved: fromExists,
+                lineagesUpdated,
+                checkpointsUpdated
+              } satisfies StoreRenameResult;
+            });
+
+            return yield* program.pipe(
+              Effect.ensuring(
+                Ref.get(state).pipe(
+                  Effect.flatMap(rollback),
+                  Effect.catchAll(() => Effect.void),
+                  Effect.uninterruptible
+                )
+              )
+            );
+          })
+      );
+
+      return StoreRenamer.of({ rename });
+    })
+  );
+}

--- a/tests/services/lineage-store.test.ts
+++ b/tests/services/lineage-store.test.ts
@@ -116,4 +116,18 @@ describe("LineageStore", () => {
       expect(result.value.sources[1].storeName).toBe("another-source");
     }
   });
+
+  test("remove deletes lineage entry", async () => {
+    const program = Effect.gen(function* () {
+      const store = yield* LineageStore;
+
+      yield* store.save(sampleLineage);
+      yield* store.remove(sampleStoreName);
+      return yield* store.get(sampleStoreName);
+    });
+
+    const result = await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
+
+    expect(Option.isNone(result)).toBe(true);
+  });
 });

--- a/tests/services/store-renamer.test.ts
+++ b/tests/services/store-renamer.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test";
+import { Effect, Layer, Option, Schema } from "effect";
+import { BunContext } from "@effect/platform-bun";
+import { FileSystem, Path } from "@effect/platform";
+import * as KeyValueStore from "@effect/platform/KeyValueStore";
+import { StoreRenamer } from "../../src/services/store-renamer.js";
+import { StoreManager } from "../../src/services/store-manager.js";
+import { StoreDb } from "../../src/services/store-db.js";
+import { LineageStore } from "../../src/services/lineage-store.js";
+import { ViewCheckpointStore } from "../../src/services/view-checkpoint-store.js";
+import { AppConfigService, ConfigOverrides } from "../../src/services/app-config.js";
+import { defaultStoreConfig } from "../../src/domain/defaults.js";
+import { StoreLineage, DerivationCheckpoint } from "../../src/domain/derivation.js";
+import { StoreName } from "../../src/domain/primitives.js";
+
+const sourceName = Schema.decodeUnknownSync(StoreName)("arsenal");
+const derivedName = Schema.decodeUnknownSync(StoreName)("arsenal-links");
+const renamedSourceName = Schema.decodeUnknownSync(StoreName)("arsenal-archive");
+const renamedDerivedName = Schema.decodeUnknownSync(StoreName)("arsenal-links-2026");
+
+const sampleLineage = Schema.decodeUnknownSync(StoreLineage)({
+  storeName: "arsenal-links",
+  isDerived: true,
+  sources: [
+    {
+      storeName: "arsenal",
+      filter: { _tag: "All" },
+      filterHash: "abc123",
+      evaluationMode: "EventTime",
+      derivedAt: "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  updatedAt: "2026-01-01T00:00:00.000Z"
+});
+
+const sampleCheckpoint = Schema.decodeUnknownSync(DerivationCheckpoint)({
+  viewName: "arsenal-links",
+  sourceStore: "arsenal",
+  targetStore: "arsenal-links",
+  filterHash: "abc123",
+  evaluationMode: "EventTime",
+  eventsProcessed: 10,
+  eventsMatched: 5,
+  deletesPropagated: 0,
+  updatedAt: "2026-01-01T00:00:00.000Z"
+});
+
+const makeTempDir = () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      return yield* fs.makeTempDirectory();
+    }).pipe(Effect.provide(BunContext.layer))
+  );
+
+const removeTempDir = (path: string) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      yield* fs.remove(path, { recursive: true });
+    }).pipe(Effect.provide(BunContext.layer))
+  );
+
+const buildLayer = (storeRoot: string) => {
+  const overrides = Layer.succeed(ConfigOverrides, { storeRoot });
+  const appConfigLayer = AppConfigService.layer.pipe(Layer.provide(overrides));
+  const managerLayer = StoreManager.layer.pipe(Layer.provideMerge(appConfigLayer));
+  const storeDbLayer = StoreDb.layer.pipe(Layer.provide(appConfigLayer));
+  const lineageLayer = LineageStore.layer.pipe(
+    Layer.provideMerge(KeyValueStore.layerMemory)
+  );
+  const viewCheckpointLayer = ViewCheckpointStore.layer.pipe(
+    Layer.provideMerge(storeDbLayer),
+    Layer.provideMerge(managerLayer)
+  );
+  const renamerLayer = StoreRenamer.layer.pipe(
+    Layer.provideMerge(appConfigLayer),
+    Layer.provideMerge(managerLayer),
+    Layer.provideMerge(storeDbLayer),
+    Layer.provideMerge(lineageLayer)
+  );
+
+  return Layer.mergeAll(
+    appConfigLayer,
+    managerLayer,
+    storeDbLayer,
+    lineageLayer,
+    viewCheckpointLayer,
+    renamerLayer
+  ).pipe(Layer.provideMerge(BunContext.layer));
+};
+
+describe("StoreRenamer", () => {
+  test("renames a source store and updates lineage sources + checkpoints", async () => {
+    const tempDir = await makeTempDir();
+    const layer = buildLayer(tempDir);
+
+    try {
+      const program = Effect.gen(function* () {
+        const manager = yield* StoreManager;
+        const renamer = yield* StoreRenamer;
+        const lineageStore = yield* LineageStore;
+        const checkpoints = yield* ViewCheckpointStore;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* manager.createStore(sourceName, defaultStoreConfig);
+        yield* manager.createStore(derivedName, defaultStoreConfig);
+
+        const sourceDir = path.join(tempDir, "stores", sourceName);
+        yield* fs.makeDirectory(sourceDir, { recursive: true });
+
+        yield* lineageStore.save(sampleLineage);
+        yield* checkpoints.save(sampleCheckpoint);
+
+        const result = yield* renamer.rename(sourceName, renamedSourceName);
+        const renamed = yield* manager.getStore(renamedSourceName);
+        const missing = yield* manager.getStore(sourceName);
+        const updatedLineage = yield* lineageStore.get(derivedName);
+        const oldCheckpoint = yield* checkpoints.load(derivedName, sourceName);
+        const newCheckpoint = yield* checkpoints.load(derivedName, renamedSourceName);
+        const newDirExists = yield* fs.exists(
+          path.join(tempDir, "stores", renamedSourceName)
+        );
+
+        return {
+          result,
+          renamed,
+          missing,
+          updatedLineage,
+          oldCheckpoint,
+          newCheckpoint,
+          newDirExists
+        };
+      });
+
+      const result = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+
+      expect(result.result.moved).toBe(true);
+      expect(Option.isSome(result.renamed)).toBe(true);
+      expect(Option.isNone(result.missing)).toBe(true);
+      expect(result.newDirExists).toBe(true);
+      expect(Option.isSome(result.updatedLineage)).toBe(true);
+      if (Option.isSome(result.updatedLineage)) {
+        expect(result.updatedLineage.value.sources[0]?.storeName).toBe(
+          renamedSourceName
+        );
+      }
+      expect(Option.isNone(result.oldCheckpoint)).toBe(true);
+      expect(Option.isSome(result.newCheckpoint)).toBe(true);
+      if (Option.isSome(result.newCheckpoint)) {
+        expect(result.newCheckpoint.value.sourceStore).toBe(renamedSourceName);
+      }
+    } finally {
+      await removeTempDir(tempDir);
+    }
+  });
+
+  test("renames a derived store and updates lineage key + checkpoint view", async () => {
+    const tempDir = await makeTempDir();
+    const layer = buildLayer(tempDir);
+
+    try {
+      const program = Effect.gen(function* () {
+        const manager = yield* StoreManager;
+        const renamer = yield* StoreRenamer;
+        const lineageStore = yield* LineageStore;
+        const checkpoints = yield* ViewCheckpointStore;
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+
+        yield* manager.createStore(sourceName, defaultStoreConfig);
+        yield* manager.createStore(derivedName, defaultStoreConfig);
+
+        const derivedDir = path.join(tempDir, "stores", derivedName);
+        yield* fs.makeDirectory(derivedDir, { recursive: true });
+
+        yield* lineageStore.save(sampleLineage);
+        yield* checkpoints.save(sampleCheckpoint);
+
+        const result = yield* renamer.rename(derivedName, renamedDerivedName);
+        const renamed = yield* manager.getStore(renamedDerivedName);
+        const missing = yield* manager.getStore(derivedName);
+        const updatedLineage = yield* lineageStore.get(renamedDerivedName);
+        const oldLineage = yield* lineageStore.get(derivedName);
+        const oldCheckpoint = yield* checkpoints.load(derivedName, sourceName);
+        const newCheckpoint = yield* checkpoints.load(renamedDerivedName, sourceName);
+        const newDirExists = yield* fs.exists(
+          path.join(tempDir, "stores", renamedDerivedName)
+        );
+
+        return {
+          result,
+          renamed,
+          missing,
+          updatedLineage,
+          oldLineage,
+          oldCheckpoint,
+          newCheckpoint,
+          newDirExists
+        };
+      });
+
+      const result = await Effect.runPromise(program.pipe(Effect.provide(layer)));
+
+      expect(result.result.moved).toBe(true);
+      expect(Option.isSome(result.renamed)).toBe(true);
+      expect(Option.isNone(result.missing)).toBe(true);
+      expect(result.newDirExists).toBe(true);
+      expect(Option.isSome(result.updatedLineage)).toBe(true);
+      expect(Option.isNone(result.oldLineage)).toBe(true);
+      if (Option.isSome(result.updatedLineage)) {
+        expect(result.updatedLineage.value.storeName).toBe(renamedDerivedName);
+      }
+      expect(Option.isNone(result.oldCheckpoint)).toBe(true);
+      expect(Option.isSome(result.newCheckpoint)).toBe(true);
+      if (Option.isSome(result.newCheckpoint)) {
+        expect(result.newCheckpoint.value.viewName).toBe(renamedDerivedName);
+        expect(result.newCheckpoint.value.targetStore).toBe(renamedDerivedName);
+      }
+    } finally {
+      await removeTempDir(tempDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add StoreRenamer orchestrator (catalog + filesystem + lineage + checkpoints)\n- add store rename CLI and wire layers\n- add StoreAlreadyExists error + docs updates\n- add tests for store renaming and lineage removal\n\n## Testing\n- bun test tests/services/store-renamer.test.ts tests/services/lineage-store.test.ts\n- bun run typecheck