### PR TITLE
Refactor tag guards and Match usage

### DIFF
--- a/docs/plans/2026-02-01-tag-guards-match-refactor.md
+++ b/docs/plans/2026-02-01-tag-guards-match-refactor.md
@@ -1,0 +1,120 @@
+# Tag Guards + Match Refactor Spec (2026-02-01)
+
+Goal: replace ad-hoc `_tag` checks and scattered union switches with Effect-idiomatic guards and `Match`-based pattern matching, reducing duplication and tightening type safety.
+
+Status: in progress (guards added for embeds/errors/events; Match refactor pending).
+
+## Why this matters
+
+- Fewer hand-rolled `_tag` checks means fewer drift bugs when unions evolve.
+- `Schema.is` / `Predicate.isTagged` provide consistent, typed refinements.
+- `Match.tagsExhaustive` gives compile-time coverage for discriminated unions.
+- Centralized match tables reduce duplication and improve readability.
+
+## Principles
+
+1) Prefer `Schema.is` for `Schema.TaggedClass` / `Schema.TaggedError` types.
+2) Use `Predicate.isTagged` only when a schema is not available.
+3) Replace large `_tag` switches with `Match.tagsExhaustive` where unions are total.
+4) Use `Match.tags` + `Match.orElse` when intentionally partial.
+5) Favor reusable match tables (`Match.typeTags` / `Match.valueTags`) for shared logic.
+
+## Current progress (done)
+
+- Embed guards and helpers:
+  - `src/domain/bsky.ts`: `isEmbed*`, `isEmbedRecordView`, `isFeedReasonRepost`
+  - `src/domain/embeds.ts`: `embedMedia`, `hasExternalEmbed`, `hasVideoEmbed`, `isQuoteEmbed`
+  - Wired into `src/cli/doc/post.ts`, `src/services/filter-runtime.ts`, `src/services/store-index-sql.ts`, `src/services/bsky-client.ts`
+- Error guards:
+  - `src/domain/errors.ts`: `isImageFetchError`, `isImageArchiveError`, `isImageCacheError`, `isStoreIoError`
+  - Wired into `src/services/images/image-fetcher.ts`, `src/services/images/image-cache.ts`, `src/services/store-stats.ts`
+- Event guards:
+  - `src/domain/events.ts`: `isPostUpsert`, `isPostDelete`
+  - Wired into `src/services/store-writer.ts`, `src/services/store-index.ts`, `src/services/derivation-engine.ts`
+- Misc:
+  - `src/cli/graph.ts`: `Either.isRight`
+  - `src/services/identity-resolver.ts`: `Exit.isFailure`
+  - `src/services/filter-library.ts`: `Schema.is(SystemError)`
+
+## High-value targets (Match refactor)
+
+These are the most impactful `_tag` switches to convert to `Match`:
+
+### Filter policies
+- `src/services/filter-runtime.ts`: `withPolicy`, `explainPolicy`
+- `src/services/filter-compiler.ts`
+- `src/domain/filter-describe.ts`
+
+### Filter expressions (AST)
+- `src/services/filter-runtime.ts`: `buildPredicate`, `buildExplainer`
+- `src/services/filter-compiler.ts`
+- `src/domain/filter-describe.ts`
+- `src/services/store-index.ts` (pushdown)
+- `src/cli/query.ts` (unicode-insensitive contains check)
+
+### Sync outcomes / sources
+- `src/domain/sync.ts`
+- `src/services/sync-engine.ts`
+- `src/services/jetstream-sync.ts`
+
+### CLI token parsing
+- `src/cli/filter-dsl.ts`
+- `src/cli/logging.ts` (warnings)
+
+## Remaining `_tag` scans (informational)
+
+Use `rg -n "_tag" src` to confirm remaining sites. After this pass, most remaining `_tag`
+uses should be inside match tables or small, local unions.
+
+## Match patterns (to standardize)
+
+### Total union
+```
+const matchPolicy = Match.type<FilterErrorPolicy>().pipe(
+  Match.tagsExhaustive({
+    Include: () => ...,
+    Exclude: () => ...,
+    Retry: (policy) => ...
+  })
+);
+```
+
+### Partial with fallback
+```
+const matchExpr = Match.type<FilterExpr>().pipe(
+  Match.tags({
+    Hashtag: (expr) => ...,
+    Author: (expr) => ...
+  }),
+  Match.orElse((expr) => ...)
+);
+```
+
+### Reusable mapping function
+```
+const describeExpr = Match.typeTags<FilterExpr>()({
+  Hashtag: (expr) => ...,
+  Author: (expr) => ...
+});
+```
+
+## Phased implementation plan
+
+1) Convert `FilterErrorPolicy` switches to `Match.tagsExhaustive`.
+2) Convert filter AST matchers to `Match`:
+   - Begin with `filter-compiler` and `filter-describe` (pure mappings).
+   - Then `filter-runtime` (effectful, but still structured).
+3) Convert sync outcome/source switches to `Match`.
+4) Convert CLI token parsing to `Match.tagsExhaustive`.
+5) Sweep for residual `_tag` checks and replace with guards or match tables.
+
+## Acceptance criteria
+
+- No ad-hoc `_tag` comparisons for domain unions (except in match tables).
+- Guard utilities centralized via `Schema.is` / `Predicate.isTagged`.
+- Match tables are exhaustive for core unions (filters, outcomes, sources).
+- Typecheck passes; tests remain green.
+
+## Related
+
+- GitHub issue #149: "Refactor: replace direct _tag checks with typed guards"

--- a/src/cli/filter-errors.ts
+++ b/src/cli/filter-errors.ts
@@ -1,4 +1,4 @@
-import { ParseResult } from "effect";
+import { ParseResult, Predicate } from "effect";
 import { safeParseJson, issueDetails, findJsonParseIssue, jsonParseTip } from "./parse-errors.js";
 import { formatAgentError, type AgentErrorPayload } from "./errors.js";
 
@@ -94,7 +94,9 @@ export const formatFilterParseError = (error: ParseResult.ParseError, raw: strin
     });
   }
 
-  const tagMissing = issues.some((issue) => issue._tag === "Missing" && hasPath(issue, "_tag"));
+  const tagMissing = issues.some(
+    (issue) => Predicate.isTagged(issue, "Missing") && hasPath(issue, "_tag")
+  );
   if (tagMissing) {
     return validationError({
       message: "Filter expression requires a _tag field.",
@@ -107,7 +109,9 @@ export const formatFilterParseError = (error: ParseResult.ParseError, raw: strin
     });
   }
 
-  const tagInvalid = issues.some((issue) => issue._tag === "Type" && hasPath(issue, "_tag"));
+  const tagInvalid = issues.some(
+    (issue) => Predicate.isTagged(issue, "Type") && hasPath(issue, "_tag")
+  );
   if (tagInvalid) {
     return validationError({
       message: `Invalid filter type${tag ? ` "${tag}"` : ""}.`,

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,5 +1,5 @@
 import { Args, Command, Options } from "@effect/cli";
-import { Effect, Option, Stream } from "effect";
+import { Either, Effect, Option, Stream } from "effect";
 import { BskyClient } from "../services/bsky-client.js";
 import { AppConfigService } from "../services/app-config.js";
 import { IdentityResolver } from "../services/identity-resolver.js";
@@ -343,7 +343,7 @@ const relationshipsCommand = Command.make(
       );
       const handleMap = new Map<string, string>();
       for (const [did, result] of handles) {
-        if (result._tag === "Right") {
+        if (Either.isRight(result)) {
           handleMap.set(did, String(result.right));
         }
       }

--- a/src/cli/parse-errors.ts
+++ b/src/cli/parse-errors.ts
@@ -1,4 +1,11 @@
+import { Predicate } from "effect";
+
 type ParseIssue = { readonly _tag: string; readonly message?: string };
+
+const isTransformationIssue = (
+  issue: ParseIssue
+): issue is ParseIssue & { readonly _tag: "Transformation" } =>
+  Predicate.isTagged(issue, "Transformation");
 
 /** Safely parse JSON, returning `undefined` on failure. */
 export const safeParseJson = (raw: string): unknown => {
@@ -14,7 +21,7 @@ export const jsonParseTip = "Tip: wrap JSON in single quotes to avoid shell esca
 export const findJsonParseIssue = (issues: ReadonlyArray<ParseIssue>) =>
   issues.find(
     (issue) =>
-      issue._tag === "Transformation" &&
+      isTransformationIssue(issue) &&
       typeof issue.message === "string" &&
       issue.message.startsWith("JSON Parse error")
   );

--- a/src/cli/store-errors.ts
+++ b/src/cli/store-errors.ts
@@ -1,4 +1,4 @@
-import { ParseResult } from "effect";
+import { ParseResult, Predicate } from "effect";
 import { safeParseJson, issueDetails, findJsonParseIssue, jsonParseTip } from "./parse-errors.js";
 import { formatAgentError } from "./errors.js";
 
@@ -50,7 +50,9 @@ export const formatStoreConfigParseError = (
     });
   }
 
-  if (issues.some((issue) => issue._tag === "Missing" && hasPath(issue, "filters"))) {
+  if (
+    issues.some((issue) => Predicate.isTagged(issue, "Missing") && hasPath(issue, "filters"))
+  ) {
     return formatAgentError({
       error: "StoreConfigValidationError",
       message: `Store config requires a filters array. ${storeConfigDocHint}`,

--- a/src/domain/bsky.ts
+++ b/src/domain/bsky.ts
@@ -198,6 +198,8 @@ export class EmbedRecordView extends Schema.TaggedClass<EmbedRecordView>()(
   }
 ) {}
 
+export const isEmbedRecordView = Schema.is(EmbedRecordView);
+
 export class EmbedRecordNotFound extends Schema.TaggedClass<EmbedRecordNotFound>()(
   "RecordNotFound",
   {
@@ -274,20 +276,12 @@ export const PostEmbed = Schema.Union(
 );
 export type PostEmbed = typeof PostEmbed.Type;
 
-const hasTag = (value: unknown, tag: string): boolean =>
-  typeof value === "object" &&
-  value !== null &&
-  "_tag" in value &&
-  (value as { readonly _tag?: unknown })._tag === tag;
-
-export const isEmbedImages = (value: unknown): value is EmbedImages =>
-  hasTag(value, "Images");
-
-export const isEmbedExternal = (value: unknown): value is EmbedExternal =>
-  hasTag(value, "External");
-
-export const isEmbedVideo = (value: unknown): value is EmbedVideo =>
-  hasTag(value, "Video");
+export const isEmbedImages = Schema.is(EmbedImages);
+export const isEmbedExternal = Schema.is(EmbedExternal);
+export const isEmbedVideo = Schema.is(EmbedVideo);
+export const isEmbedRecord = Schema.is(EmbedRecord);
+export const isEmbedRecordWithMedia = Schema.is(EmbedRecordWithMedia);
+export const isEmbedUnknown = Schema.is(EmbedUnknown);
 
 export const PostViewerState = Schema.Struct({
   repost: Schema.optional(AtUri),
@@ -382,6 +376,8 @@ export const FeedReason = Schema.Union(
   FeedReasonUnknown
 );
 export type FeedReason = typeof FeedReason.Type;
+
+export const isFeedReasonRepost = Schema.is(FeedReasonRepost);
 
 export class FeedContext extends Schema.Class<FeedContext>("FeedContext")({
   reply: Schema.optional(FeedReplyRef),

--- a/src/domain/errors.ts
+++ b/src/domain/errors.ts
@@ -33,6 +33,7 @@ export class ImageFetchError extends Schema.TaggedError<ImageFetchError>()(
     status: Schema.optional(Schema.Number)
   }
 ) {}
+export const isImageFetchError = Schema.is(ImageFetchError);
 
 export class ImageArchiveError extends Schema.TaggedError<ImageArchiveError>()(
   "ImageArchiveError",
@@ -43,6 +44,7 @@ export class ImageArchiveError extends Schema.TaggedError<ImageArchiveError>()(
     cause: Schema.optional(Schema.Unknown)
   }
 ) {}
+export const isImageArchiveError = Schema.is(ImageArchiveError);
 
 export class ImageCacheError extends Schema.TaggedError<ImageCacheError>()(
   "ImageCacheError",
@@ -53,6 +55,7 @@ export class ImageCacheError extends Schema.TaggedError<ImageCacheError>()(
     status: Schema.optional(Schema.Number)
   }
 ) {}
+export const isImageCacheError = Schema.is(ImageCacheError);
 
 export class ConfigError extends Schema.TaggedError<ConfigError>()(
   "ConfigError",
@@ -82,6 +85,7 @@ export class StoreIoError extends Schema.TaggedError<StoreIoError>()(
   "StoreIoError",
   { path: StorePath, cause: Schema.Unknown }
 ) {}
+export const isStoreIoError = Schema.is(StoreIoError);
 
 export class StoreIndexError extends Schema.TaggedError<StoreIndexError>()(
   "StoreIndexError",

--- a/src/domain/events.ts
+++ b/src/domain/events.ts
@@ -26,12 +26,14 @@ export class PostUpsert extends Schema.TaggedClass<PostUpsert>()("PostUpsert", {
   post: Post,
   meta: EventMeta
 }) {}
+export const isPostUpsert = Schema.is(PostUpsert);
 
 export class PostDelete extends Schema.TaggedClass<PostDelete>()("PostDelete", {
   uri: PostUri,
   cid: Schema.optional(PostCid),
   meta: EventMeta
 }) {}
+export const isPostDelete = Schema.is(PostDelete);
 
 export const PostEvent = Schema.Union(PostUpsert, PostDelete);
 export type PostEvent = typeof PostEvent.Type;

--- a/src/services/bsky-client.ts
+++ b/src/services/bsky-client.ts
@@ -112,6 +112,9 @@ import {
   EmbedRecordWithMedia,
   EmbedUnknown,
   EmbedVideo,
+  isEmbedExternal,
+  isEmbedImages,
+  isEmbedVideo,
   FeedContext,
   FeedGeneratorView,
   FeedPostBlocked,
@@ -786,9 +789,9 @@ const mapEmbedView = (
         );
         const media: PostEmbed | unknown =
           mediaCandidate &&
-          (mediaCandidate._tag === "Images" ||
-            mediaCandidate._tag === "External" ||
-            mediaCandidate._tag === "Video")
+          (isEmbedImages(mediaCandidate) ||
+            isEmbedExternal(mediaCandidate) ||
+            isEmbedVideo(mediaCandidate))
             ? mediaCandidate
             : (embed as { media?: unknown }).media;
         const mapped: EmbedRecordTarget = yield* mapEmbedRecordTarget(record ?? embed);

--- a/src/services/derivation-engine.ts
+++ b/src/services/derivation-engine.ts
@@ -83,7 +83,7 @@ import {
   StoreLineage,
   StoreSource
 } from "../domain/derivation.js";
-import { EventMeta, PostDelete, PostUpsert } from "../domain/events.js";
+import { EventMeta, PostDelete, PostUpsert, isPostDelete } from "../domain/events.js";
 import type { EventLogEntry } from "../domain/events.js";
 import { EventSeq, Timestamp } from "../domain/primitives.js";
 import type { FilterCompileError, FilterEvalError, StoreIndexError, StoreIoError } from "../domain/errors.js";
@@ -359,7 +359,7 @@ export class DerivationEngine extends Context.Tag("@skygent/DerivationEngine")<
                 };
 
                 // PostDelete: propagate ALL unfiltered
-                if (event._tag === "PostDelete") {
+                if (isPostDelete(event)) {
                   const derivedMeta = EventMeta.make({
                     ...event.meta,
                     sourceStore: sourceRef.name

--- a/src/services/identity-resolver.ts
+++ b/src/services/identity-resolver.ts
@@ -24,6 +24,7 @@ import {
   Config,
   Context,
   Duration,
+  Exit,
   Effect,
   Layer,
   Option,
@@ -497,7 +498,7 @@ export class IdentityResolver extends Context.Tag("@skygent/IdentityResolver")<
           capacity: requestCapacity,
           lookup,
           timeToLive: (exit) =>
-            exit._tag === "Failure" ? failureTtl : cacheTtl
+            Exit.isFailure(exit) ? failureTtl : cacheTtl
         }).pipe(Effect.map(Option.some));
       };
 

--- a/src/services/shared.ts
+++ b/src/services/shared.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, ParseResult } from "effect";
+import { Effect, ParseResult, Predicate } from "effect";
 import { ConfigError } from "../domain/errors.js";
 
 /** Extract a human-readable message from an unknown cause, falling back to the given string. */
@@ -38,7 +38,7 @@ export const formatParseError = (
 
   const jsonParseIssue = issues.find(
     (issue) =>
-      issue._tag === "Transformation" &&
+      Predicate.isTagged(issue, "Transformation") &&
       typeof issue.message === "string" &&
       issue.message.startsWith("JSON Parse error")
   );

--- a/src/services/store-stats.ts
+++ b/src/services/store-stats.ts
@@ -51,7 +51,7 @@ import { DataSource, type SyncCheckpoint } from "../domain/sync.js";
 import { StoreName, type StorePath } from "../domain/primitives.js";
 import { StoreRef } from "../domain/store.js";
 import type { StoreLineage } from "../domain/derivation.js";
-import { StoreIoError, type StoreIndexError } from "../domain/errors.js";
+import { StoreIoError, isStoreIoError, type StoreIndexError } from "../domain/errors.js";
 import { updatedAtOrder } from "../domain/order.js";
 
 /**
@@ -136,11 +136,8 @@ const parseCount = (value: unknown) =>
  * @returns A function that converts causes to StoreIoError
  */
 const toStoreIoError = (path: StorePath) => (cause: unknown) => {
-  if (typeof cause === "object" && cause !== null) {
-    const tagged = cause as { _tag?: string };
-    if (tagged._tag === "StoreIoError") {
-      return tagged as StoreIoError;
-    }
+  if (isStoreIoError(cause)) {
+    return cause;
   }
   return StoreIoError.make({ path, cause });
 };

--- a/src/services/store-writer.ts
+++ b/src/services/store-writer.ts
@@ -2,7 +2,7 @@ import { Clock, Context, Effect, Layer, Option, Random, Schema, SynchronizedRef 
 import type * as SqlClient from "@effect/sql/SqlClient";
 import * as SqlSchema from "@effect/sql/SqlSchema";
 import { StoreIoError } from "../domain/errors.js";
-import { type EventLogEntry, PostEvent, PostEventRecord } from "../domain/events.js";
+import { type EventLogEntry, PostEvent, PostEventRecord, isPostUpsert } from "../domain/events.js";
 import { EventId, EventSeq, PostUri } from "../domain/primitives.js";
 import type { StorePath } from "../domain/primitives.js";
 import type { StoreRef } from "../domain/store.js";
@@ -148,10 +148,9 @@ export class StoreWriter extends Context.Tag("@skygent/StoreWriter")<
             const payloadJson = yield* Schema.encode(
               Schema.parseJson(PostEventRecord)
             )(record);
-            const postUri =
-              record.event._tag === "PostUpsert"
-                ? record.event.post.uri
-                : record.event.uri;
+            const postUri = isPostUpsert(record.event)
+              ? record.event.post.uri
+              : record.event.uri;
             const createdAt =
               record.event.meta.createdAt instanceof Date
                 ? record.event.meta.createdAt.toISOString()


### PR DESCRIPTION
## Summary\n- replace remaining _tag checks with Predicate/Match across filters, sync engines, CLI parsing, and pushdown\n- standardize filter AST matching and guard usage\n- add tag-guard/match refactor plan doc\n\n## Testing\n- bun run typecheck\n- bun test