### PR TITLE
Fix pipe TTY detection in tests

### DIFF
--- a/src/cli/input.ts
+++ b/src/cli/input.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline";
 
 export interface CliInputService {
   readonly lines: Stream.Stream<string, PlatformError>;
+  readonly isTTY: boolean;
 }
 
 const makeLines = () =>
@@ -39,7 +40,8 @@ export class CliInput extends Context.Tag("@skygent/CliInput")<
   static readonly layer = Layer.succeed(
     CliInput,
     CliInput.of({
-      lines: makeLines()
+      lines: makeLines(),
+      isTTY: Boolean(process.stdin.isTTY)
     })
   );
 }

--- a/src/cli/pipe.ts
+++ b/src/cli/pipe.ts
@@ -65,15 +65,14 @@ export const pipeCommand = Command.make(
   { filter: filterOption, filterJson: filterJsonOption, onError: onErrorOption, batchSize: batchSizeOption },
   ({ filter, filterJson, onError, batchSize }) =>
     Effect.gen(function* () {
-      if (process.stdin.isTTY) {
+      const input = yield* CliInput;
+      if (input.isTTY) {
         return yield* CliInputError.make({
           message: "stdin is a TTY. Pipe NDJSON input into skygent pipe.",
           cause: { isTTY: true }
         });
       }
       yield* requireFilterExpr(filter, filterJson);
-
-      const input = yield* CliInput;
       const parser = yield* PostParser;
       const runtime = yield* FilterRuntime;
       const expr = yield* parseFilterExpr(filter, filterJson);

--- a/tests/cli/pipe.test.ts
+++ b/tests/cli/pipe.test.ts
@@ -64,7 +64,8 @@ const makeOutputCapture = () => {
 
 const makeInputLayer = (lines: ReadonlyArray<string>) => {
   const service: CliInputService = {
-    lines: Stream.fromIterable(lines)
+    lines: Stream.fromIterable(lines),
+    isTTY: false
   };
   return Layer.succeed(CliInput, CliInput.of(service));
 };


### PR DESCRIPTION
## Summary\n- add isTTY to CliInput service\n- use CliInput.isTTY in pipe command instead of process.stdin\n- set isTTY=false in pipe tests\n\n## Testing\n- bun test tests/cli/pipe.test.ts