### PR TITLE
feat: extend image cache tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,16 @@ skygent query my-store --limit 25 --format table
 skygent query my-store --filter 'hashtag:#ai' --sort desc --format json
 skygent query my-store --range 2024-01-01T00:00:00Z..2024-01-31T00:00:00Z
 skygent query my-store --fields @minimal --newest-first
+skygent query my-store --fields @images --resolve-images
+skygent query my-store --extract-images --format json
 skygent query store-a,store-b --format ndjson
 ```
 
 **Formats:** `json`, `ndjson`, `table`, `markdown`, `compact`, `card`, `thread`
 
-**Field presets:** `@minimal`, `@social`, `@full`, or comma-separated field names with dot notation.
+**Field presets:** `@minimal`, `@social`, `@full`, `@images`, `@embeds`, `@media`, or comma-separated field names with dot notation (use `*` to traverse arrays, e.g. `images.*.alt`).
+
+**Image options:** `--extract-images`, `--resolve-images`, `--cache-images` (requires images in output), `--no-cache-images-thumbnails`.
 
 Multi-store queries accept comma-separated store lists or repeated store arguments and include store names in output by default.
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -60,6 +60,16 @@ Each entry shows a DSL example and the equivalent JSON shape.
   - `{ "_tag": "Engagement", "minLikes": 100, "minReplies": 5 }`
 - Images: `hasimages` or `images`
   - `{ "_tag": "HasImages" }`
+- Minimum images: `min-images:2`
+  - `{ "_tag": "MinImages", "min": 2 }`
+- Has alt text: `has:alt-text`
+  - `{ "_tag": "HasAltText" }`
+- No alt text: `no-alt-text`
+  - `{ "_tag": "NoAltText" }`
+- Alt text: `alt-text:"diagram"`
+  - `{ "_tag": "AltText", "text": "diagram" }`
+- Alt text regex: `alt-text:/diagram/i`
+  - `{ "_tag": "AltTextRegex", "pattern": "diagram", "flags": "i" }`
 - Video: `hasvideo` or `video`
   - `{ "_tag": "HasVideo" }`
 - Links: `haslinks`

--- a/docs/filters/reference.md
+++ b/docs/filters/reference.md
@@ -37,6 +37,16 @@ Need a quick predicate list? Run `skygent filter help`.
   - `{"_tag":"Engagement","minLikes":100,"minReplies":5}`
 - Images: `hasimages`
   - `{"_tag":"HasImages"}`
+- Minimum images: `min-images:2`
+  - `{"_tag":"MinImages","min":2}`
+- Has alt text: `has:alt-text`
+  - `{"_tag":"HasAltText"}`
+- No alt text: `no-alt-text`
+  - `{"_tag":"NoAltText"}`
+- Alt text: `alt-text:"diagram"`
+  - `{"_tag":"AltText","text":"diagram"}`
+- Alt text regex: `alt-text:/diagram/i`
+  - `{"_tag":"AltTextRegex","pattern":"diagram","flags":"i"}`
 - Video: `hasvideo`
   - `{"_tag":"HasVideo"}`
 - Links: `haslinks`
@@ -93,7 +103,7 @@ Defaults:
 - `authors:alice,bob` → `authorin:alice,bob`
 - `tags:#ai,#ml` → `hashtagin:#ai,#ml`
 - `is:reply|quote|repost|original`
-- `has:images|video|links|media|embed`
+- `has:images|video|links|media|embed|alt-text`
 
 ## Named filters
 

--- a/src/cli/app.ts
+++ b/src/cli/app.ts
@@ -18,6 +18,7 @@ import { graphCommand } from "./graph.js";
 import { feedCommand } from "./feed.js";
 import { postCommand } from "./post.js";
 import { pipeCommand } from "./pipe.js";
+import { imageCacheCommand } from "./image-cache-command.js";
 import { configCommand } from "./config-command.js";
 import {
   configOptions,
@@ -41,6 +42,7 @@ export const app = Command.make("skygent", configOptions).pipe(
     graphCommand,
     feedCommand,
     postCommand,
+    imageCacheCommand,
     pipeCommand
   ]),
   Command.provide((config) =>

--- a/src/cli/filter-help.ts
+++ b/src/cli/filter-help.ts
@@ -10,6 +10,10 @@ const filterJsonExamples = [
   "  Engagement:      '{\"_tag\":\"Engagement\",\"minLikes\":100}'",
   "  Has media:       '{\"_tag\":\"HasMedia\"}'",
   "  Has embed:       '{\"_tag\":\"HasEmbed\"}'",
+  "  Min images:      '{\"_tag\":\"MinImages\",\"min\":2}'",
+  "  Has alt text:    '{\"_tag\":\"HasAltText\"}'",
+  "  No alt text:     '{\"_tag\":\"NoAltText\"}'",
+  "  Alt text:        '{\"_tag\":\"AltText\",\"text\":\"diagram\"}'",
   "  Language:        '{\"_tag\":\"Language\",\"langs\":[\"en\",\"es\"]}'",
   "  By regex:        '{\"_tag\":\"Regex\",\"patterns\":[\"pattern\"],\"flags\":\"i\"}'",
   "  Trending tag:    '{\"_tag\":\"Trending\",\"tag\":\"#ai\",\"onError\":{\"_tag\":\"Include\"}}'",
@@ -43,6 +47,10 @@ const filterDslExamples = [
   "  hasmedia",
   "  hasembed",
   "  has:images",
+  "  min-images:2",
+  "  has:alt-text",
+  "  no-alt-text",
+  "  alt-text:\"diagram\"",
   "  language:en,es",
   "  @tech AND author:user.bsky.social",
   "  date:2024-01-01T00:00:00Z..2024-01-31T00:00:00Z",
@@ -61,7 +69,7 @@ const filterDslExamples = [
   "  authors:alice,bob             -> authorin:alice,bob",
   "  tags:#ai,#ml                  -> hashtagin:#ai,#ml",
   "  is:reply|quote|repost|original",
-  "  has:images|video|links|media|embed"
+  "  has:images|video|links|media|embed|alt-text"
 ].join("\n");
 
 export const filterDslDescription = () =>

--- a/src/cli/image-cache-command.ts
+++ b/src/cli/image-cache-command.ts
@@ -1,0 +1,46 @@
+import { Command, Options } from "@effect/cli";
+import { Effect } from "effect";
+import { cacheTtlSweep } from "./image-cache.js";
+import { writeJson } from "./output.js";
+import { withExamples } from "./help.js";
+
+const sweepForceOption = Options.boolean("force").pipe(
+  Options.withAlias("f"),
+  Options.withDescription("Delete expired cache files (default: dry-run)")
+);
+const sweepThumbnailsOption = Options.boolean("thumbnails").pipe(
+  Options.withDescription("Include thumbnails when sweeping expired cache files")
+);
+
+const sweepCommand = Command.make(
+  "sweep",
+  { thumbnails: sweepThumbnailsOption, force: sweepForceOption },
+  ({ thumbnails, force }) =>
+    Effect.gen(function* () {
+      const result = yield* cacheTtlSweep({
+        includeThumbnails: thumbnails,
+        remove: force
+      });
+      yield* writeJson(result);
+    })
+).pipe(
+  Command.withDescription(
+    withExamples(
+      "Sweep expired image cache files (TTL-based)",
+      [
+        "skygent image-cache sweep",
+        "skygent image-cache sweep --thumbnails --force"
+      ],
+      ["Tip: omit --force to run a dry sweep first."]
+    )
+  )
+);
+
+export const imageCacheCommand = Command.make("image-cache", {}).pipe(
+  Command.withSubcommands([sweepCommand]),
+  Command.withDescription(
+    withExamples("Manage the image cache", [
+      "skygent image-cache sweep"
+    ])
+  )
+);

--- a/src/cli/image-cache.ts
+++ b/src/cli/image-cache.ts
@@ -1,5 +1,5 @@
 import { FileSystem, Path } from "@effect/platform";
-import { Effect, Exit, Option, Ref, Stream } from "effect";
+import { Clock, Duration, Effect, Exit, Option, Ref, Stream } from "effect";
 import type { StoreRef } from "../domain/store.js";
 import { StoreQuery } from "../domain/events.js";
 import { extractImageRefs } from "../domain/embeds.js";
@@ -191,6 +191,217 @@ export const cacheStatusForStore = (
       cacheRoot,
       includeThumbnails: options.includeThumbnails,
       ...(options.limit !== undefined ? { limit: options.limit } : {})
+    };
+  });
+
+export const cacheSweepForStore = (
+  store: StoreRef,
+  options: CacheImagesOptions & { readonly remove?: boolean }
+) =>
+  Effect.gen(function* () {
+    const cache = yield* ImageCache;
+    const config = yield* ImageConfig;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const seenRef = yield* Ref.make(new Set<string>());
+    const referencedRef = yield* Ref.make(new Set<string>());
+
+    const stream = yield* buildEntryStream(
+      store,
+      options.includeThumbnails,
+      Option.none()
+    );
+
+    const collectEntry = (entry: CacheEntry) =>
+      Effect.gen(function* () {
+        const shouldProcess = yield* Ref.modify(seenRef, (seen) => {
+          const key = entryKey(entry);
+          if (seen.has(key)) {
+            return [false, seen] as const;
+          }
+          const next = new Set(seen);
+          next.add(key);
+          return [true, next] as const;
+        });
+        if (!shouldProcess) {
+          return { cached: 0, skipped: 0, errors: 0 } satisfies CacheProgress;
+        }
+        const cached = yield* cache.getCached(entry.url, entry.variant);
+        if (Option.isSome(cached)) {
+          const normalized = path.normalize(cached.value.path);
+          yield* Ref.update(referencedRef, (set) => {
+            const next = new Set(set);
+            next.add(normalized);
+            return next;
+          });
+          return { cached: 1, skipped: 0, errors: 0 } satisfies CacheProgress;
+        }
+        return { cached: 0, skipped: 1, errors: 0 } satisfies CacheProgress;
+      });
+
+    const progress = yield* stream.pipe(
+      Stream.mapEffect(collectEntry, { concurrency: 10 }),
+      Stream.runFold(initialProgress, mapProgress)
+    );
+    const referenced = yield* Ref.get(referencedRef);
+
+    const cacheRoot = config.cacheRoot;
+    const exists = yield* fs.exists(cacheRoot).pipe(Effect.orElseSucceed(() => false));
+    if (!exists) {
+      return {
+        store: store.name,
+        referencedFiles: referenced.size,
+        scannedFiles: 0,
+        orphanedFiles: 0,
+        removedFiles: 0,
+        includeThumbnails: options.includeThumbnails,
+        dryRun: !options.remove
+      };
+    }
+
+    const entries = yield* fs
+      .readDirectory(cacheRoot, { recursive: true })
+      .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+    const files = yield* Effect.forEach(
+      entries,
+      (entry) =>
+        Effect.gen(function* () {
+          const absolute = path.isAbsolute(entry)
+            ? entry
+            : path.join(cacheRoot, entry);
+          const info = yield* fs.stat(absolute).pipe(Effect.orElseSucceed(() => undefined));
+          if (!info || info.type !== "File") {
+            return Option.none<string>();
+          }
+          const relative = path.isAbsolute(entry)
+            ? path.relative(cacheRoot, absolute)
+            : entry;
+          const normalized = path.normalize(relative);
+          if (normalized === "meta" || normalized.startsWith(`meta${path.sep}`)) {
+            return Option.none<string>();
+          }
+          if (!options.includeThumbnails && normalized.startsWith(`thumb${path.sep}`)) {
+            return Option.none<string>();
+          }
+          return Option.some(normalized);
+        }),
+      { concurrency: 20 }
+    );
+    const fileList = files.flatMap((item) => (Option.isSome(item) ? [item.value] : []));
+    const orphaned = fileList.filter((file) => !referenced.has(file));
+
+    if (options.remove && orphaned.length > 0) {
+      yield* Effect.forEach(
+        orphaned,
+        (relativePath) =>
+          fs
+            .remove(path.join(cacheRoot, relativePath), { force: true })
+            .pipe(Effect.orElseSucceed(() => undefined)),
+        { discard: true, concurrency: 10 }
+      );
+    }
+
+    return {
+      store: store.name,
+      referencedImages: progress.cached,
+      missingImages: progress.skipped,
+      referencedFiles: referenced.size,
+      scannedFiles: fileList.length,
+      orphanedFiles: orphaned.length,
+      removedFiles: options.remove ? orphaned.length : 0,
+      includeThumbnails: options.includeThumbnails,
+      dryRun: !options.remove
+    };
+  });
+
+type CacheTtlSweepProgress = {
+  readonly scanned: number;
+  readonly expired: number;
+  readonly removed: number;
+};
+
+const initialTtlProgress: CacheTtlSweepProgress = { scanned: 0, expired: 0, removed: 0 };
+
+const mergeTtlProgress = (
+  left: CacheTtlSweepProgress,
+  right: CacheTtlSweepProgress
+): CacheTtlSweepProgress => ({
+  scanned: left.scanned + right.scanned,
+  expired: left.expired + right.expired,
+  removed: left.removed + right.removed
+});
+
+export const cacheTtlSweep = (options: { readonly remove?: boolean; readonly includeThumbnails?: boolean }) =>
+  Effect.gen(function* () {
+    const config = yield* ImageConfig;
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const now = yield* Clock.currentTimeMillis;
+    const ttlMillis = Duration.toMillis(config.cacheTtl);
+    const includeThumbnails = options.includeThumbnails ?? true;
+
+    const roots = includeThumbnails
+      ? [config.originalsRoot, config.thumbsRoot]
+      : [config.originalsRoot];
+
+    const sweepRoot = (root: string) =>
+      Effect.gen(function* () {
+        const exists = yield* fs.exists(root).pipe(Effect.orElseSucceed(() => false));
+        if (!exists) return initialTtlProgress;
+        const entries = yield* fs
+          .readDirectory(root, { recursive: true })
+          .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+        return yield* Effect.forEach(
+          entries,
+          (entry) =>
+            Effect.gen(function* () {
+              const absolute = path.isAbsolute(entry) ? entry : path.join(root, entry);
+              const info = yield* fs.stat(absolute).pipe(Effect.orElseSucceed(() => undefined));
+              if (!info || info.type !== "File") {
+                return initialTtlProgress;
+              }
+              const mtime = Option.getOrUndefined(info.mtime);
+              const expired = ttlMillis === 0
+                ? true
+                : mtime
+                  ? now - mtime.getTime() >= ttlMillis
+                  : false;
+              if (!expired) {
+                return { scanned: 1, expired: 0, removed: 0 } satisfies CacheTtlSweepProgress;
+              }
+              if (!options.remove) {
+                return { scanned: 1, expired: 1, removed: 0 } satisfies CacheTtlSweepProgress;
+              }
+              const removed = yield* fs
+                .remove(absolute, { force: true })
+                .pipe(
+                  Effect.as(1),
+                  Effect.orElseSucceed(() => 0)
+                );
+              return {
+                scanned: 1,
+                expired: 1,
+                removed
+              } satisfies CacheTtlSweepProgress;
+            }),
+          { concurrency: 20 }
+        ).pipe(Effect.map((items) => items.reduce(mergeTtlProgress, initialTtlProgress)));
+      });
+
+    const progress = yield* Effect.forEach(
+      roots,
+      (root) => sweepRoot(root),
+      { concurrency: 2 }
+    ).pipe(Effect.map((items) => items.reduce(mergeTtlProgress, initialTtlProgress)));
+
+    return {
+      cacheRoot: config.cacheRoot,
+      ttlMillis,
+      scannedFiles: progress.scanned,
+      expiredFiles: progress.expired,
+      removedFiles: progress.removed,
+      includeThumbnails,
+      dryRun: !options.remove
     };
   });
 

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -68,7 +68,9 @@ const untilOption = Options.text("until").pipe(
 );
 const limitOption = Options.integer("limit").pipe(
   Options.withSchema(PositiveInt),
-  Options.withDescription("Maximum number of posts to return"),
+  Options.withDescription(
+    "Maximum number of posts to return (or images when --extract-images)"
+  ),
   Options.optional
 );
 const scanLimitOption = Options.integer("scan-limit").pipe(
@@ -100,7 +102,7 @@ const widthOption = Options.integer("width").pipe(
 );
 const fieldsOption = Options.text("fields").pipe(
   Options.withDescription(
-    "Comma-separated fields to include (supports dot notation and presets: @minimal, @social, @images, @embeds, @media, @full). Use author or authorProfile.handle for handles."
+    "Comma-separated fields to include (supports dot notation, `*` for arrays, and presets: @minimal, @social, @images, @embeds, @media, @full). Use author or authorProfile.handle for handles."
   ),
   Options.optional
 );
@@ -137,17 +139,16 @@ type ImageExtract = {
 };
 
 type FieldSelector = {
-  readonly path: ReadonlyArray<string>;
-  readonly wildcard: boolean;
+  readonly prefix: ReadonlyArray<string>;
+  readonly suffix: ReadonlyArray<string>;
+  readonly wildcard: "none" | "object" | "array";
 };
 
 const isAscii = (value: string) => /^[\x00-\x7F]*$/.test(value);
 
 const selectorsIncludeImages = (selectors: ReadonlyArray<FieldSelector>) =>
   selectors.some(
-    (selector) =>
-      selector.path[0] === "images" ||
-      (selector.wildcard && selector.path.length === 0)
+    (selector) => selector.prefix[0] === "images"
   );
 
 const hasUnicodeInsensitiveContains = (expr: FilterExpr): boolean =>

--- a/src/cli/shared-options.ts
+++ b/src/cli/shared-options.ts
@@ -68,6 +68,12 @@ export const cacheImagesLimitOption = Options.integer("cache-images-limit").pipe
   Options.optional
 );
 
+export const noCacheImagesThumbnailsOption = Options.boolean(
+  "no-cache-images-thumbnails"
+).pipe(
+  Options.withDescription("Disable thumbnail caching when caching images")
+);
+
 /** --strict flag to stop on first error */
 export const strictOption = Options.boolean("strict").pipe(
   Options.withDescription("Stop on first error and do not advance the checkpoint")

--- a/src/cli/sync-factory.ts
+++ b/src/cli/sync-factory.ts
@@ -24,6 +24,7 @@ export interface CommonCommandInput {
   readonly cacheImages: boolean;
   readonly cacheImagesMode: Option.Option<CacheImagesMode>;
   readonly cacheImagesLimit: Option.Option<number>;
+  readonly noCacheImagesThumbnails: boolean;
   readonly limit?: Option.Option<number>;
 }
 
@@ -108,7 +109,7 @@ export const makeSyncCommandBody = (
               postsAdded: result.postsAdded
             });
             const cacheResult = yield* cacheStoreImages(storeRef, {
-              includeThumbnails: true,
+              includeThumbnails: !input.noCacheImagesThumbnails,
               ...(cacheLimit !== undefined ? { limit: cacheLimit } : {})
             });
             yield* logInfo("Image cache complete", cacheResult);
@@ -169,7 +170,7 @@ export const makeWatchCommandBody = (
             source: sourceName
           });
           const cacheResult = yield* cacheStoreImages(storeRef, {
-            includeThumbnails: true,
+            includeThumbnails: !input.noCacheImagesThumbnails,
             ...(Option.isSome(input.cacheImagesLimit)
               ? { limit: input.cacheImagesLimit.value }
               : {})
@@ -215,7 +216,7 @@ export const makeWatchCommandBody = (
                       postsAdded: result.postsAdded
                     });
                     const cacheResult = yield* cacheStoreImages(storeRef, {
-                      includeThumbnails: true,
+                      includeThumbnails: !input.noCacheImagesThumbnails,
                       ...(cacheLimit !== undefined && cacheLimit > 0
                         ? { limit: cacheLimit }
                         : {})

--- a/src/cli/sync.ts
+++ b/src/cli/sync.ts
@@ -34,6 +34,7 @@ import {
   cacheImagesOption,
   cacheImagesModeOption,
   cacheImagesLimitOption,
+  noCacheImagesThumbnailsOption,
   strictOption,
   maxErrorsOption
 } from "./shared-options.js";
@@ -78,6 +79,7 @@ const timelineCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
   makeSyncCommandBody("timeline", () => DataSource.timeline())
@@ -106,6 +108,7 @@ const feedCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
   ({ uri, ...rest }) => makeSyncCommandBody("feed", () => DataSource.feed(uri), { uri })(rest)
@@ -133,6 +136,7 @@ const listCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
   ({ uri, ...rest }) => makeSyncCommandBody("list", () => DataSource.list(uri), { uri })(rest)
@@ -159,6 +163,7 @@ const notificationsCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
   makeSyncCommandBody("notifications", () => DataSource.notifications())
@@ -186,9 +191,10 @@ const authorCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
-  ({ actor, filter, includePins, postFilter, postFilterJson, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, limit }) =>
+  ({ actor, filter, includePins, postFilter, postFilterJson, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, noCacheImagesThumbnails, limit }) =>
     Effect.gen(function* () {
       const apiFilter = Option.getOrUndefined(filter);
       const source = DataSource.author(actor, {
@@ -209,6 +215,7 @@ const authorCommand = Command.make(
         cacheImages,
         cacheImagesMode,
         cacheImagesLimit,
+        noCacheImagesThumbnails,
         limit
       });
     })
@@ -239,9 +246,10 @@ const threadCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: syncLimitOption
   },
-  ({ uri, depth, parentHeight, filter, filterJson, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, limit }) =>
+  ({ uri, depth, parentHeight, filter, filterJson, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, noCacheImagesThumbnails, limit }) =>
     Effect.gen(function* () {
       const { depth: depthValue, parentHeight: parentHeightValue } =
         parseThreadDepth(depth, parentHeight);
@@ -254,7 +262,18 @@ const threadCommand = Command.make(
         ...(depthValue !== undefined ? { depth: depthValue } : {}),
         ...(parentHeightValue !== undefined ? { parentHeight: parentHeightValue } : {})
       });
-      return yield* run({ store, filter, filterJson, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, limit });
+      return yield* run({
+        store,
+        filter,
+        filterJson,
+        quiet,
+        refresh,
+        cacheImages,
+        cacheImagesMode,
+        cacheImagesLimit,
+        noCacheImagesThumbnails,
+        limit
+      });
     })
 ).pipe(
   Command.withDescription(
@@ -285,6 +304,7 @@ const jetstreamCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     limit: jetstreamLimitOption,
     duration: durationOption,
     strict: strictOption,
@@ -304,6 +324,7 @@ const jetstreamCommand = Command.make(
     cacheImages,
     cacheImagesMode,
     cacheImagesLimit,
+    noCacheImagesThumbnails,
     limit,
     duration,
     strict,
@@ -390,7 +411,7 @@ const jetstreamCommand = Command.make(
               postsAdded: result.postsAdded
             });
             const cacheResult = yield* cacheStoreImages(storeRef, {
-              includeThumbnails: true,
+              includeThumbnails: !noCacheImagesThumbnails,
               ...(cacheLimit !== undefined ? { limit: cacheLimit } : {})
             });
             yield* logInfo("Image cache complete", cacheResult);

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -32,6 +32,7 @@ import {
   cacheImagesOption,
   cacheImagesModeOption,
   cacheImagesLimitOption,
+  noCacheImagesThumbnailsOption,
   strictOption,
   maxErrorsOption
 } from "./shared-options.js";
@@ -79,7 +80,8 @@ const timelineCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
   makeWatchCommandBody("timeline", () => DataSource.timeline())
 ).pipe(
@@ -109,7 +111,8 @@ const feedCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
   ({ uri, ...rest }) => makeWatchCommandBody("feed", () => DataSource.feed(uri), { uri })(rest)
 ).pipe(
@@ -138,7 +141,8 @@ const listCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
   ({ uri, ...rest }) => makeWatchCommandBody("list", () => DataSource.list(uri), { uri })(rest)
 ).pipe(
@@ -166,7 +170,8 @@ const notificationsCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
   makeWatchCommandBody("notifications", () => DataSource.notifications())
 ).pipe(
@@ -195,9 +200,10 @@ const authorCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
-  ({ actor, filter, includePins, postFilter, postFilterJson, interval, maxCycles, until, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit }) =>
+  ({ actor, filter, includePins, postFilter, postFilterJson, interval, maxCycles, until, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, noCacheImagesThumbnails }) =>
     Effect.gen(function* () {
       const apiFilter = Option.getOrUndefined(filter);
       const source = DataSource.author(actor, {
@@ -220,7 +226,8 @@ const authorCommand = Command.make(
         refresh,
         cacheImages,
         cacheImagesMode,
-        cacheImagesLimit
+        cacheImagesLimit,
+        noCacheImagesThumbnails
       });
     })
 ).pipe(
@@ -252,9 +259,10 @@ const threadCommand = Command.make(
     refresh: refreshOption,
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
-    cacheImagesLimit: cacheImagesLimitOption
+    cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption
   },
-  ({ uri, depth, parentHeight, filter, filterJson, interval, maxCycles, until, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit }) =>
+  ({ uri, depth, parentHeight, filter, filterJson, interval, maxCycles, until, store, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit, noCacheImagesThumbnails }) =>
     Effect.gen(function* () {
       const { depth: depthValue, parentHeight: parentHeightValue } =
         parseThreadDepth(depth, parentHeight);
@@ -267,7 +275,20 @@ const threadCommand = Command.make(
         ...(depthValue !== undefined ? { depth: depthValue } : {}),
         ...(parentHeightValue !== undefined ? { parentHeight: parentHeightValue } : {})
       });
-      return yield* run({ store, filter, filterJson, interval, maxCycles, until, quiet, refresh, cacheImages, cacheImagesMode, cacheImagesLimit });
+      return yield* run({
+        store,
+        filter,
+        filterJson,
+        interval,
+        maxCycles,
+        until,
+        quiet,
+        refresh,
+        cacheImages,
+        cacheImagesMode,
+        cacheImagesLimit,
+        noCacheImagesThumbnails
+      });
     })
 ).pipe(
   Command.withDescription(
@@ -300,6 +321,7 @@ const jetstreamCommand = Command.make(
     cacheImages: cacheImagesOption,
     cacheImagesMode: cacheImagesModeOption,
     cacheImagesLimit: cacheImagesLimitOption,
+    noCacheImagesThumbnails: noCacheImagesThumbnailsOption,
     strict: strictOption,
     maxErrors: maxErrorsOption
   },
@@ -319,6 +341,7 @@ const jetstreamCommand = Command.make(
     cacheImages,
     cacheImagesMode,
     cacheImagesLimit,
+    noCacheImagesThumbnails,
     strict,
     maxErrors
   }) =>
@@ -355,7 +378,7 @@ const jetstreamCommand = Command.make(
             source: "jetstream"
           });
           const cacheResult = yield* cacheStoreImages(storeRef, {
-            includeThumbnails: true,
+            includeThumbnails: !noCacheImagesThumbnails,
             ...(Option.isSome(cacheImagesLimit)
               ? { limit: cacheImagesLimit.value }
               : {})
@@ -402,7 +425,7 @@ const jetstreamCommand = Command.make(
                         postsAdded: result.postsAdded
                       });
                       const cacheResult = yield* cacheStoreImages(storeRef, {
-                        includeThumbnails: true,
+                        includeThumbnails: !noCacheImagesThumbnails,
                         ...(cacheLimit !== undefined && cacheLimit > 0
                           ? { limit: cacheLimit }
                           : {})

--- a/src/domain/order.ts
+++ b/src/domain/order.ts
@@ -3,9 +3,8 @@ import type { Post } from "./post.js";
 import type { StoreRef } from "./store.js";
 
 export const LocaleStringOrder = Order.make<string>((left, right) => {
-  const result = left.localeCompare(right);
-  if (result < 0) return -1;
-  if (result > 0) return 1;
+  if (left < right) return -1;
+  if (left > right) return 1;
   return 0;
 });
 

--- a/tests/cli/doc/post.test.ts
+++ b/tests/cli/doc/post.test.ts
@@ -73,6 +73,48 @@ describe("renderPostCard", () => {
     expect(output).toContain("[Images: 1]");
   });
 
+  test("renders image alt text details", () => {
+    const post = makePost({
+      embed: {
+        _tag: "Images",
+        images: [
+          { thumb: "t1", fullsize: "f1", alt: "First image" },
+          { thumb: "t2", fullsize: "f2", alt: "Second image" },
+          { thumb: "t3", fullsize: "f3", alt: "Third image" }
+        ]
+      }
+    });
+    const output = renderPlain(Doc.vsep(renderPostCard(post)));
+    expect(output).toContain("alt: First image");
+    expect(output).toContain("alt: Second image");
+    expect(output).toContain("alt: +1 more");
+  });
+
+  test("renders embed summary for record with media images", () => {
+    const post = makePost({
+      embed: {
+        _tag: "RecordWithMedia",
+        record: {
+          _tag: "RecordView",
+          uri: "at://did:plc:abc/app.bsky.feed.post/456",
+          cid: "bafyrecordcid",
+          author: { did: "did:plc:abc", handle: "bob.test" },
+          value: {},
+          indexedAt: "2024-01-15T12:00:00Z"
+        },
+        media: {
+          _tag: "Images",
+          images: [
+            { thumb: "t1", fullsize: "f1", alt: "" },
+            { thumb: "t2", fullsize: "f2", alt: "" }
+          ]
+        }
+      }
+    });
+    const output = renderPlain(Doc.vsep(renderPostCard(post)));
+    expect(output).toContain("[Quote: @bob.test + 2 images]");
+  });
+
   test("renders embed summary for external link", () => {
     const post = makePost({
       embed: { _tag: "External", uri: "https://example.com", title: "Example", description: "" }

--- a/tests/cli/query-fields.test.ts
+++ b/tests/cli/query-fields.test.ts
@@ -42,6 +42,48 @@ describe("query fields", () => {
     });
   });
 
+  test("projects array subfields with wildcard", async () => {
+    const selectorsOption = await Effect.runPromise(
+      parseFieldSelectors("images.*.alt")
+    );
+    expect(Option.isSome(selectorsOption)).toBe(true);
+    if (selectorsOption._tag === "None") return;
+
+    const source = {
+      images: [
+        { alt: "First", fullsizeUrl: "full1" },
+        { alt: "Second", fullsizeUrl: "full2" }
+      ],
+      author: "alice"
+    };
+    const projected = projectFields(source, selectorsOption.value);
+    expect(projected).toEqual({
+      images: [{ alt: "First" }, { alt: "Second" }]
+    });
+  });
+
+  test("merges array wildcard projections", async () => {
+    const selectorsOption = await Effect.runPromise(
+      parseFieldSelectors("images.*.alt,images.*.fullsizeUrl")
+    );
+    expect(Option.isSome(selectorsOption)).toBe(true);
+    if (selectorsOption._tag === "None") return;
+
+    const source = {
+      images: [
+        { alt: "First", fullsizeUrl: "full1" },
+        { alt: "Second", fullsizeUrl: "full2" }
+      ]
+    };
+    const projected = projectFields(source, selectorsOption.value);
+    expect(projected).toEqual({
+      images: [
+        { alt: "First", fullsizeUrl: "full1" },
+        { alt: "Second", fullsizeUrl: "full2" }
+      ]
+    });
+  });
+
   test("returns none for @full", async () => {
     const selectorsOption = await Effect.runPromise(parseFieldSelectors("@full"));
     expect(Option.isNone(selectorsOption)).toBe(true);


### PR DESCRIPTION
## Summary
- add TTL-based cache sweeps and CLI commands (global + store)
- add array wildcard field selectors and embed/image output coverage
- improve cache invalidation/missing-file handling and docs/tests

## Testing
- bun test
- bun run typecheck